### PR TITLE
ChangeNOW.io added to the list of exchanges

### DIFF
--- a/_includes/home/exchanges.html
+++ b/_includes/home/exchanges.html
@@ -104,6 +104,9 @@
                 <a href="https://www.independentreserve.com/" target="_blank"><img alt="Independent Reserve" src="/img/exchanges/independentreserve.png"></a>
             </div>
             <div class="col-sm-4 col-md-3 vertical-align to-animate">
+                <a href="https://changenow.io/" target="_blank"><img alt="ChangeNOW" src="/img/exchanges/changenow.png"></a>
+            </div>
+            <div class="col-sm-4 col-md-3 vertical-align to-animate">
                 <a href="https://www.bitstamp.net/" target="_blank"><img alt="Bitstamp" src="/img/exchanges/bitstamp.png"></a>
             </div>
             <div class="col-sm-4 col-md-3 vertical-align to-animate">


### PR DESCRIPTION
The scam accusations against changeNow were not justified.
Adding it back to the list of exchanges.