### PR TITLE
unambiguously but succinctly specify the CTOR algorithm

### DIFF
--- a/spec/2018-nov-upgrade.md
+++ b/spec/2018-nov-upgrade.md
@@ -1,9 +1,9 @@
 ---
 layout: specification
 title: 2018 November 15 Network Upgrade Specification
-date: 2018-08-24
+date: 2018-09-10
 activation: 1542300000
-version: 0.3
+version: 0.4
 ---
 
 ## Summary
@@ -22,7 +22,7 @@ The following are not consensus changes, but are recommended changes for Bitcoin
 
 ## Canonical Transaction Order
 
-With the exception of the coinbase transaction, transactions within a block MUST be sorted by the numerically ascending order of 256-bit little endian integers constructed by deserializing the bytes of the transaction id (formed from the double sha256 hash of the transaction data).  The coinbase transaction shall be the first transaction in a block.
+With the exception of the coinbase transaction, transactions within a block MUST be sorted in numerically ascending order of the transaction id, interpreted as 256-bit little endian integers.  The coinbase transaction MUST be the first transaction in a block.
 
 ## OpCodes
 

--- a/spec/2018-nov-upgrade.md
+++ b/spec/2018-nov-upgrade.md
@@ -22,7 +22,7 @@ The following are not consensus changes, but are recommended changes for Bitcoin
 
 ## Canonical Transaction Order
 
-With the exception of the coinbase transaction, transactions within a block shall be sorted by Transaction ID in ascending order. The coinbase transaction shall be the first transaction in a block.
+With the exception of the coinbase transaction, transactions within a block MUST be sorted by the numerically ascending order of 256-bit little endian integers constructed by deserializing the bytes of the transaction id (formed from the double sha256 hash of the transaction data).  The coinbase transaction shall be the first transaction in a block.
 
 ## OpCodes
 


### PR DESCRIPTION
Since the sha256 algorithm produces an array of bytes, its completely unclear what the sort algorithm is, especially since some are calling it LTOR (lexical transaction ordering), yet lexical ordering (of the binary bytes) would produce a very different result.  Additional sources of confusion are that the bitcoind hash print function reverses the bytes, so printed lexical ordering works.  

Non-satoshi implementations may need this specified clearly since they may not have the uint256 object that makes the chosen order convenient.  And the uint256 in many satoshi clients overloads < to be big endian lexical ordering.   So best to clear this up in an authoritative spec.