### PR TITLE
Add BU Cash 1.5.0.0 to website

### DIFF
--- a/_includes/home/about.html
+++ b/_includes/home/about.html
@@ -87,6 +87,9 @@
                     <a href="https://download.bitcoinabc.org/0.18.2/" title="Bitcoin ABC 0.18.2" target="_blank">
                         <i class="fa fa-link" aria-hidden="true"></i> Bitcoin ABC 0.18.2
                     </a>
+                    <a href="https://github.com/BitcoinUnlimited/BitcoinUnlimited/blob/dev/doc/release-notes/release-notes-bucash1.5.0.0.md" title="Bitcoin Unlimited Cash Edition 1.5.0.0" target="_blank">
+                        <i class="fa fa-link" aria-hidden="true"></i> Bitcoin Unlimited Cash Edition 1.5.0.0
+                    </a>
                     <a href="https://twitter.com/Bcoin/status/1033054171870556161" title="bcoin bcash" target="_blank">
                         <i class="fa fa-link" aria-hidden="true"></i> bcoin - bcash 1.1.0 (coming soon)
                     </a>


### PR DESCRIPTION
Add Bitcoin Unlimited Cash Edition 1.5.0.0 to bitcoincash.org under "Compatible Implementations" for the Nov Upgrade.