### PR TITLE
Clarifying that OP_CDS(V) just uses the stack

### DIFF
--- a/spec/op_checkdatasig.md
+++ b/spec/op_checkdatasig.md
@@ -1,9 +1,9 @@
 ---
 layout: specification
 title: OP_CHECKDATASIG and OP_CHECKDATASIGVERIFY Specification
-date: 2018-08-20
+date: 2018-10-16
 activation: 1542300000
-version: 0.6
+version: 0.7
 ---
 
 OP_CHECKDATASIG

--- a/spec/op_checkdatasig.md
+++ b/spec/op_checkdatasig.md
@@ -9,7 +9,7 @@ version: 0.6
 OP_CHECKDATASIG
 ===============
 
-OP_CHECKDATASIG and OP_CHECKDATASIGVERIFY check whether a signature is valid with respect to a message and a public key.
+OP_CHECKDATASIG and OP_CHECKDATASIGVERIFY check whether the data on the stack represents a valid ECDSA signature, message, and public key.
 
 OP_CHECKDATASIG permits data to be imported into a script, and have its validity checked against some signing authority such as an "Oracle".
 


### PR DESCRIPTION
@Mengerian could you modify the OP_CDS(V) spec to make it clear in the introduction section that OP_CDSV takes a signature off of the stack and verifies it? I've seen a few people on Twitter claiming that it can fetch the signature from another transaction, which allows you to "call" another transaction, which allows looping, and other nonsense like that. Making it clear that you're just processing data off the stack might help a little.