### PR TITLE
Update links to Schnorr information

### DIFF
--- a/spec/20190515-schnorr.md
+++ b/spec/20190515-schnorr.md
@@ -1,6 +1,10 @@
 In-Progress Schnorr Draft Specification
 =======================================
 
-A draft specification is being worked on [here](https://github.com/markblundeberg/bitcoincash.org/blob/53b0d2adafe3ba8d79e3831a1df9bd516597f4c4/spec/schnorr-spec.md)
+A draft specification is being worked on in a [Pull Request](https://github.com/bitcoincashorg/bitcoincash.org/pull/207/files), which will supersede this document when it is merged.
+
+Mathematical specification by Peter Wuille [here](https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr.mediawiki)
 
 Implementation work is taking place [here](https://reviews.bitcoinabc.org/D2169)
+
+Telegram discussion group [here](https://t.me/joinchat/HCYr50bcT1vAH0SkOF0Nfw)


### PR DESCRIPTION
Update the links to point to Mark Lundeberg's pull request, and a few other sources useful information.

I guess for process, one way to proceed would be to keep the spec as a PR for a while so that people can comment on it easily.

Alternatively, it could be merged, but in that case we'd need to add prominent notice that it's a work in progress. Either way seems OK, I prefer leaving the full spec as a PR for now because I think that's the clearest thing, and avoids possibly confusing people.