### PR TITLE
[spec] Add"draft" warning to 2019 May 15 upgrade

### DIFF
--- a/spec/20190515-may-upgrade.md
+++ b/spec/20190515-may-upgrade.md
@@ -6,6 +6,8 @@ activation: 1557921600
 version: 0.1 DRAFT SUBJECT TO CHANGE
 ---
 
+**Important: This document is an in-progress draft, and likely to change prior to the 2019-05-15 upgrade**
+
 ## Summary
 
 When the median time past [1] of the most recent 11 blocks (MTP-11) is greater than or equal to UNIX timestamp 1557921600, Bitcoin Cash will execute an upgrade of the network consensus rules according to this specification. Starting from the next block these consensus rules changes will take effect:

--- a/spec/20190515-reenabled-opcodes.md
+++ b/spec/20190515-reenabled-opcodes.md
@@ -6,6 +6,8 @@ version: 1.0
 updated: 2018-08-13
 ---
 
+**Important: This document is an in-progress draft, and likely to change prior to the 2019-05-15 upgrade**
+
 # Introduction
 
 In May 2018 several disabled opcodes were reintroduced to the Bitcoin Cash scripting engine2. The scope of that change was limited in order to focus developer attention rather than attempting to reintroduce all of the disabled opcodes at once. This specification expands upon that change by reintroducing additional opcodes.


### PR DESCRIPTION
It is very important that people not be confused about the status of these documents as in-progress draft, subject to change.

Add prominent warnings to make sure people don't miss it.