### PR TITLE
Beautified URLs

### DIFF
--- a/_includes/accept-bitcoin-cash/accept-bitcoin-cash.html
+++ b/_includes/accept-bitcoin-cash/accept-bitcoin-cash.html
@@ -59,7 +59,7 @@
             </div>
         </div>
         <div class="row text-center">
-            <a href="spend-bitcoin-cash.html" class="card-user-profile-button btn btn-secondary btn-round secondary">&laquo; {% t 'spendbch.title' %}</a>
+            <a href="spend-bitcoin-cash" class="card-user-profile-button btn btn-secondary btn-round secondary">&laquo; {% t 'spendbch.title' %}</a>
         </div>
     </div>
 </section>

--- a/_includes/buy-bitcoin-cash/buy-bitcoin-cash.html
+++ b/_includes/buy-bitcoin-cash/buy-bitcoin-cash.html
@@ -125,6 +125,6 @@
 {% include exchanges/exchanges.html %}
 
 <div class="row text-center">
-    <a href="wallets.html" class="card-user-profile-button btn btn-secondary btn-round secondary">&laquo; {% t 'downloadwallet.title' %}</a>
-    <a href="spend-bitcoin-cash.html" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'spendbch.title' %} &raquo;</a>
+    <a href="wallets" class="card-user-profile-button btn btn-secondary btn-round secondary">&laquo; {% t 'downloadwallet.title' %}</a>
+    <a href="spend-bitcoin-cash" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'spendbch.title' %} &raquo;</a>
 </div>

--- a/_includes/getting-started/getting-started.html
+++ b/_includes/getting-started/getting-started.html
@@ -73,14 +73,13 @@
                         <p class="card-user-profile-info">{% t 'gettingstarted.description' %}</p>
                     </div>
                     <div class="card-user-profile-actions">
-                        <a href="faq.html" class="btn btn-primary btn-round">Learn More</a>
+                        <a href="faq" class="btn btn-primary btn-round">Learn More</a>
                     </div>
                 </div>
-            
             </div>
         </div>
         <div class="row text-center">
-            <a href="wallets.html" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'downloadwallet.title' %} &raquo;</a>
+            <a href="wallets" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'downloadwallet.title' %} &raquo;</a>
         </div>
     </div>
 </section>

--- a/_includes/home/about.html
+++ b/_includes/home/about.html
@@ -92,11 +92,11 @@
                 <div class="col-sm-12 col-lg-8 col-lg-offset-2 text-center">
                     <p><strong>{% t 'headings.roadmap' %}</strong></p>
                     <p>To become a solid base for application development and innovation, Bitcoin Cash must continuously improve and compete. Working together, we can build a technical foundation to empower Bitcoin Cash to be the best money the world has ever seen.</p>
-                    
-                    <a class="btn btn-primary large btn-round" href="roadmap.html">
+
+                    <a class="btn btn-primary large btn-round" href="roadmap">
                        View The Roadmap
                     </a>
-                    
+
                 </div>
             </div>
         </div>

--- a/_includes/home/header.html
+++ b/_includes/home/header.html
@@ -6,7 +6,7 @@
                 <h4>{% t 'layout.leadsubtitle' %}</h4>
 
                 <a href="#step-section" class="btn btn-default inner-link" data-scroll-class="-30vh:active">{% t 'layout.herobutton_one' %}</a>
-                <a href="wallets.html" class="btn btn-default">{% t 'layout.herobutton_two' %}</a>
+                <a href="wallets" class="btn btn-default">{% t 'layout.herobutton_two' %}</a>
 
 
             </div>

--- a/_includes/home/wallets.html
+++ b/_includes/home/wallets.html
@@ -86,7 +86,7 @@
                 <a href="https://walletgenerator.net/?currency=BitcoinCash" target="_blank"><img alt="WalletGenerator.net" src="/img/wallets/walletgenerator.png"></a>
             </div>
             <div class="col-sm-12 text-center">
-                <a href="get-listed.html" class="btn btn-default">{% t 'headings.listingrequest' %}</a>
+                <a href="get-listed" class="btn btn-default">{% t 'headings.listingrequest' %}</a>
             </div>
         </div>
     </div>

--- a/_includes/main-menu.html
+++ b/_includes/main-menu.html
@@ -11,22 +11,22 @@
                         </a>
                     </li>
                     <li>
-                        <a href="start-here.html" class="external">
+                        <a href="start-here" class="external">
                             <span>{% t 'sections.starthere' %}</span>
                         </a>
                     </li>
                     <li>
-                        <a href="nodes.html" class="external">
+                        <a href="nodes" class="external">
                             <span>{% t 'sections.nodes' %}</span>
                         </a>
                     </li>
                     <li>
-                        <a href="wallets.html" class="external">
+                        <a href="wallets" class="external">
                             <span>{% t 'sections.wallets' %}</span>
                         </a>
                     </li>
                     <li>
-                        <a href="graphics.html" class="external">
+                        <a href="graphics" class="external">
                             <span>{% t 'sections.graphics' %}</span>
                         </a>
                     </li>
@@ -38,24 +38,24 @@
                                     <div class="dropdown__content col-md-{%- t 'misc.dropdown_md_width' %} col-sm-{%- t 'misc.dropdown_sm_width' -%}">
                                         <ul class="menu-vertical">
                                             <li>
-                                                <a href="services.html" class="external">
+                                                <a href="services" class="external">
                                                     {% t 'sections.services' %}
                                                 </a>
                                             </li>
 
 
                                             <li>
-                                                <a href="projects.html" class="external">
+                                                <a href="projects" class="external">
                                                     {% t 'sections.projects' %}
                                                 </a>
                                             </li>
                                             <li>
-                                                <a href="exchanges.html" class="external">
+                                                <a href="exchanges" class="external">
                                                     {% t 'sections.exchanges' %}
                                                 </a>
                                             </li>
                                             <!-- <li>
-                                                <a href="developers.html" class="external">
+                                                <a href="developers" class="external">
                                                     {% t 'sections.developers' %}
                                                 </a>
                                             </li> -->
@@ -66,7 +66,7 @@
                         </div>
                     </li>
                     <li>
-                        <a href="faq.html" class="external">
+                        <a href="faq" class="external">
                             <span>{% t 'sections.faq' %}</span>
                         </a>
                     </li>

--- a/_includes/spend/spend.html
+++ b/_includes/spend/spend.html
@@ -66,7 +66,7 @@
             </div>
         </div>
         <div class="row text-center">
-            <a href="buy-bitcoin-cash" class="card-user-profile-button btn btn-secondary btn-round secondary">&laquo; {% t 'buyorearn.title' %}</a>
+            <a href="buy-bitcoin-cash.html" class="card-user-profile-button btn btn-secondary btn-round secondary">&laquo; {% t 'buyorearn.title' %}</a>
             <a href="accept-bitcoin-cash" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'acceptbch.title' %} &raquo;</a>
         </div>
     </div>

--- a/_includes/spend/spend.html
+++ b/_includes/spend/spend.html
@@ -66,8 +66,8 @@
             </div>
         </div>
         <div class="row text-center">
-            <a href="buy-bitcoin-cash.html" class="card-user-profile-button btn btn-secondary btn-round secondary">&laquo; {% t 'buyorearn.title' %}</a>
-            <a href="accept-bitcoin-cash.html" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'acceptbch.title' %} &raquo;</a>
+            <a href="buy-bitcoin-cash" class="card-user-profile-button btn btn-secondary btn-round secondary">&laquo; {% t 'buyorearn.title' %}</a>
+            <a href="accept-bitcoin-cash" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'acceptbch.title' %} &raquo;</a>
         </div>
     </div>
 </section>

--- a/_includes/start/start-here.html
+++ b/_includes/start/start-here.html
@@ -50,7 +50,7 @@
             <div class="row">
                 <div class="col-sm-12 col-md-6">
                     <div class="card-user-profile card-step3">
-                        <a href="buy-bitcoin-cash">
+                        <a href="buy-bitcoin-cash.html">
                             <img class="card-user-profile-img" src="/img/buy-bitcoin-cash.jpg" alt="{% t 'buyorearn.title' %} Bitcoin Cash Coin with Coinbase Behind" />
                         </a>
                         <div class="card-user-profile-content card-section">
@@ -63,7 +63,7 @@
                         </div>
 
                         <div class="card-user-profile-actions">
-                            <a href="buy-bitcoin-cash" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'viewmore' %}</a>
+                            <a href="buy-bitcoin-cash.html" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'viewmore' %}</a>
                         </div>
                     </div>
                 </div>

--- a/_includes/start/start-here.html
+++ b/_includes/start/start-here.html
@@ -10,7 +10,7 @@
             <div class="row">
                 <div class="col-sm-12 col-md-6">
                     <div class="card-user-profile card-step1">
-                        <a href="getting-started.html">
+                        <a href="getting-started">
                             <img class="card-user-profile-img" src="/img/getting-started.jpg" alt="{% t 'gettingstarted.title' %} Getting Started Bitcoin Cash" />
                         </a>
                         <div class="card-user-profile-content card-section">
@@ -23,13 +23,13 @@
                         </div>
 
                         <div class="card-user-profile-actions">
-                            <a href="getting-started.html" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'viewmore' %}</a>
+                            <a href="getting-started" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'viewmore' %}</a>
                         </div>
                     </div>
                 </div>
                 <div class="col-sm-12 col-md-6">
                     <div class="card-user-profile card-step2">
-                        <a href="wallets.html">
+                        <a href="wallets">
                             <img class="card-user-profile-img" src="/img/bitcoin-cash-wallet.jpg" alt="{% t 'downloadwallet.title' %} Bitcoin Cash Wallet on iPhone and Macbook" />
                         </a>
                         <div class="card-user-profile-content card-section">
@@ -42,7 +42,7 @@
                         </div>
 
                         <div class="card-user-profile-actions">
-                            <a href="wallets.html" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'viewmore' %}</a>
+                            <a href="wallets" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'viewmore' %}</a>
                         </div>
                     </div>
                 </div>
@@ -50,7 +50,7 @@
             <div class="row">
                 <div class="col-sm-12 col-md-6">
                     <div class="card-user-profile card-step3">
-                        <a href="buy-bitcoin-cash.html">
+                        <a href="buy-bitcoin-cash">
                             <img class="card-user-profile-img" src="/img/buy-bitcoin-cash.jpg" alt="{% t 'buyorearn.title' %} Bitcoin Cash Coin with Coinbase Behind" />
                         </a>
                         <div class="card-user-profile-content card-section">
@@ -63,13 +63,13 @@
                         </div>
 
                         <div class="card-user-profile-actions">
-                            <a href="buy-bitcoin-cash.html" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'viewmore' %}</a>
+                            <a href="buy-bitcoin-cash" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'viewmore' %}</a>
                         </div>
                     </div>
                 </div>
                 <div class="col-sm-12 col-md-6">
                     <div class="card-user-profile card-step4">
-                        <a href="spend-bitcoin-cash.html">
+                        <a href="spend-bitcoin-cash">
                             <img class="card-user-profile-img" src="/img/spend-bitcoin-cash.jpg" alt="{% t 'spendbch.title' %} - Tokyo Shibuya Crossing Bitcoin Cash" />
                         </a>
                         <div class="card-user-profile-content card-section">
@@ -82,7 +82,7 @@
                         </div>
 
                         <div class="card-user-profile-actions">
-                            <a href="spend-bitcoin-cash.html" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'viewmore' %}</a>
+                            <a href="spend-bitcoin-cash" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'viewmore' %}</a>
                         </div>
                     </div>
                 </div>
@@ -90,7 +90,7 @@
             <div class="row">
                 <div class="col-sm-12 col-md-6 col-md-offset-3">
                     <div class="card-user-profile card-step5">
-                        <a href="accept-bitcoin-cash.html">
+                        <a href="accept-bitcoin-cash">
                             <img class="card-user-profile-img" src="/img/accept-bitcoin-cash.jpg" alt="{% t 'acceptbch.title' %} - iPad accepting Bitcoin Cash" />
                         </a>
                         <div class="card-user-profile-content card-section">
@@ -103,7 +103,7 @@
                         </div>
 
                         <div class="card-user-profile-actions">
-                            <a href="accept-bitcoin-cash.html" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'viewmore' %}</a>
+                            <a href="accept-bitcoin-cash" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'viewmore' %}</a>
                         </div>
                     </div>
                 </div>

--- a/_includes/wallets/wallets.html
+++ b/_includes/wallets/wallets.html
@@ -436,7 +436,7 @@
 		</div>
 		<div class="row text-center">
 			<a href="getting-started" class="card-user-profile-button btn btn-secondary btn-round secondary">&laquo; {% t 'gettingstarted.title' %}</a>
-			<a href="buy-bitcoin-cash" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'buyorearn.title' %} &raquo;</a>
+			<a href="buy-bitcoin-cash.html" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'buyorearn.title' %} &raquo;</a>
 		</div>
 	</div>
 </section>

--- a/_includes/wallets/wallets.html
+++ b/_includes/wallets/wallets.html
@@ -435,8 +435,8 @@
 			</div>
 		</div>
 		<div class="row text-center">
-			<a href="getting-started.html" class="card-user-profile-button btn btn-secondary btn-round secondary">&laquo; {% t 'gettingstarted.title' %}</a>
-			<a href="buy-bitcoin-cash.html" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'buyorearn.title' %} &raquo;</a>
+			<a href="getting-started" class="card-user-profile-button btn btn-secondary btn-round secondary">&laquo; {% t 'gettingstarted.title' %}</a>
+			<a href="buy-bitcoin-cash" class="card-user-profile-button btn btn-secondary btn-round secondary">{% t 'buyorearn.title' %} &raquo;</a>
 		</div>
 	</div>
 </section>

--- a/accept-bitcoin-cash.html
+++ b/accept-bitcoin-cash.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: title.acceptbch
+permalink: accept-bticoin-cash
 ---
 
 {% include main-menu.html %}

--- a/accept-bitcoin-cash.html
+++ b/accept-bitcoin-cash.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: title.acceptbch
-permalink: accept-bticoin-cash
+permalink: accept-bitcoin-cash
 ---
 
 {% include main-menu.html %}

--- a/buy-bitcoin-cash.html
+++ b/buy-bitcoin-cash.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: title.buyorearn
+permalink: buy-bitcoin-cash
 ---
 
 {% include main-menu.html %}

--- a/developers.html
+++ b/developers.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: title.developers
+permalink: developers
 submenus:
   - developers
 ---

--- a/exchanges.html
+++ b/exchanges.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: title.exchanges
+permalink: exchanges
 ---
 
 {% include main-menu.html %}

--- a/faq.html
+++ b/faq.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: headings.faq
-
+permalink: faq
 ---
 
 {% include main-menu.html %}

--- a/get-listed.html
+++ b/get-listed.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: title.get-listed
+permalink: get-listed
 ---
 {% include main-menu.html %}
 {% include get-listed/header.html %}

--- a/getting-started.html
+++ b/getting-started.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: title.gettingstarted
+permalink: getting-started
 ---
 
 {% include main-menu.html %}

--- a/graphics.html
+++ b/graphics.html
@@ -1,9 +1,10 @@
 ---
 layout: page
 title: title.graphics
+permalink: graphics
 submenus:
   - graphics
---- 
+---
 {% include main-menu.html %}
 {% include graphics/header.html %}
 {% include graphics/logos.html %}

--- a/network-upgrade.html
+++ b/network-upgrade.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: title.network-upgrade
+permalink: network-upgrade
 ---
 {% include main-menu.html %}
 {% include network-upgrade/header.html %}

--- a/nodes.html
+++ b/nodes.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: title.nodes
+permalink: nodes
 ---
 
 {% include main-menu.html %}

--- a/projects.html
+++ b/projects.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: title.projects
+permalink: projects
 ---
 
 {% include main-menu.html %}

--- a/roadmap.html
+++ b/roadmap.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: title.roadmap
+permalink: roadmap
 ---
 
 {% include main-menu.html %}

--- a/services.html
+++ b/services.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: title.services
+permalink: services
 ---
 
 {% include main-menu.html %}

--- a/specs.html
+++ b/specs.html
@@ -2,7 +2,7 @@
 layout: page
 title: title.specs
 permalink: specs
-submenus
+submenus:
   - specs
 ---
 {% include main-menu.html %}

--- a/specs.html
+++ b/specs.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: title.specs
+permalink: specs
 submenus
   - specs
 ---

--- a/spend-bitcoin-cash.html
+++ b/spend-bitcoin-cash.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: title.spendbch
+permalink: spend-bitcoin-cash
 ---
 
 {% include main-menu.html %}

--- a/start-here.html
+++ b/start-here.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: title.starthere
-
+permalink: start-here
 ---
 
 {% include main-menu.html %}

--- a/tools.html
+++ b/tools.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: title.tools
+permalink: tools
 submenus:
   - tools
 ---

--- a/wallets.html
+++ b/wallets.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: title.wallets
-
+permalink: wallets
 ---
 
 {% include main-menu.html %}

--- a/workgroups.html
+++ b/workgroups.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: title.workgroups
+permalink: workgroups
 submenus:
   - workgroups
 ---


### PR DESCRIPTION
#### Used permalinks to beautify URLs removing the ".html" extension.

#### Example:
`bitcoincash.org/wallets.html` becomes `bitcoincash.org/wallets`