### PR TITLE
removed coinify due to not supporting Bitcoin Cash (BCH) - https://he…

### DIFF
--- a/_includes/services/services.html
+++ b/_includes/services/services.html
@@ -17,9 +17,6 @@
                 <a href="https://www.coinpayments.net/" target="_blank"><img alt="CoinPayments" src="/img/services/coinpayments.png"></a>
             </div>
             <div class="col-sm-4 col-md-3 vertical-align to-animate">
-                <a href="https://news.coinify.com/coinify-merchants-accept-bitcoin-cash/" target="_blank"><img alt="Coinify" src="/img/services/coinify.png"></a>
-            </div>
-            <div class="col-sm-4 col-md-3 vertical-align to-animate">
                 <a href="https://coingate.com/" target="_blank"><img alt="CoinGate" src="/img/services/coingate.png"></a>
             </div>
             <div class="col-sm-4 col-md-3 vertical-align to-animate">


### PR DESCRIPTION
…lp.coinify.com/article/108-list-of-supported-blockchain-currencies