### PR TITLE
[spec] Remove defunct items from May 2019 Upgrade Spec

### DIFF
--- a/spec/2019-05-15-upgrade.md
+++ b/spec/2019-05-15-upgrade.md
@@ -1,9 +1,9 @@
 ---
 layout: specification
 title: 2019-MAY-15 Network Upgrade Specification
-date: 2019-02-09
+date: 2019-02-14
 activation: 1557921600
-version: 0.3 DRAFT SUBJECT TO CHANGE
+version: 0.4 DRAFT SUBJECT TO CHANGE
 ---
 
 **Important: This document is an in-progress draft, and likely to change prior to the 2019-05-15 upgrade**
@@ -13,9 +13,7 @@ version: 0.3 DRAFT SUBJECT TO CHANGE
 When the median time past [1] of the most recent 11 blocks (MTP-11) is greater than or equal to UNIX timestamp 1557921600, Bitcoin Cash will execute an upgrade of the network consensus rules according to this specification. Starting from the next block these consensus rules changes will take effect:
 
 * Enable Schnorr signatures.
-* Enforce NULLDUMMY (BIP0147).
 * Allow Segwit recovery.
-* Replace transaction size >100 byte requirement with transaction size not equal 64 bytes.
 
 The following are not consensus changes, but are recommended changes for Bitcoin Cash implementations:
 
@@ -25,24 +23,11 @@ The following are not consensus changes, but are recommended changes for Bitcoin
 
 Support Schnorr signatures in CHECKSIG and CHECKDATASIG per [2019-05-15-schnorr.md](2019-05-15-schnorr.md).
 
-## Enforce NULLDUMMY (BIP0147)
-
-As per [BIP0147](https://github.com/bitcoin/bips/blob/master/bip-0147.mediawiki) (originally [BIP0062](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki) rule 7), enforce that the dummy element consumed by OP_CHECKMULSIG(VERIFY) is an empty stack element (as is pushed by OP_0). This will go into effect at the consensus layer.
-
 ## Allow Segwit recovery
 
 In the last upgrade, coins accidentally sent to Segwit P2SH addresses were made unspendable by the CLEANSTACK rule. This upgrade will make an exemption for these coins and return them to the previous situation, where they can be taken by any miner.
 
 Details: [2019-05-15-segwit-recovery.md](2019-05-15-segwit-recovery.md)
-
-## Allow transactions <100 bytes, except 64 bytes specifically
-
-Replace transaction size >100 byte requirement with transaction size not equal 64 bytes.
-
-This rule prevents a hash griding attack, where SPV wallets can confuse a 64 byte transaction for a merkle node.
-The amount of entropy in each 32-byte sections of the transaction is insufficient to prevent a preimage attack. 
-In this case, a valid transaction could be found with a hash equal
-to the first, or last, 32 bytes of a 64-byte transaction.
 
 ## Automatic Replay Protection
 


### PR DESCRIPTION
Based on discussion at the most recent BCH developer meeting, it appears that neither NULLFAIL nor the 100-byte Tx size limit will be ready for inclusion.