### PR TITLE
Tighten up Segwit recovery wording.

### DIFF
--- a/spec/2019-05-15-upgrade.md
+++ b/spec/2019-05-15-upgrade.md
@@ -31,7 +31,7 @@ As per [BIP0147](https://github.com/bitcoin/bips/blob/master/bip-0147.mediawiki)
 
 ## Allow Segwit recovery
 
-In the last upgrade, coins accidentally sent to Segwit P2SH addresses were made unspendable by the CLEANSTACK rule. This upgrade will make an exemption for these coins and return them to the previous situation, where they can be taken by any miner.
+In the last upgrade, coins accidentally sent to Segwit P2SH addresses were made unspendable by the CLEANSTACK rule. This upgrade will make an exemption for these coins and return them to the previous situation, where they are spendable. This means that once the P2SH redeem script pre-image is revealed (for example by spending coins from the corresponding BTC address), any miner can take the coins. 
 
 Details: [2019-05-15-segwit-recovery.md](2019-05-15-segwit-recovery.md)
 


### PR DESCRIPTION
Clarify that the coins can only be taken by others if the P2SH Redeem Script pre-image is revealed.