### PR TITLE
Add BCHD to Upgrade compatible implementations list

### DIFF
--- a/_includes/home/about.html
+++ b/_includes/home/about.html
@@ -45,6 +45,9 @@
           <a href="https://download.bitcoinabc.org/0.19.0/" title="Bitcoin ABC 0.19.0" target="_blank">
               <ion-icon name="link"></ion-icon> Bitcoin ABC 0.19.0
           </a>
+          <a href="https://github.com/gcash/bchd/releases/tag/v0.14.0" title="BCHD 0.14.0" target="_blank">
+              <ion-icon name="link"></ion-icon> BCHD 0.14.0
+          </a>
           <!-- <a href="https://github.com/BitcoinUnlimited/BitcoinUnlimited/blob/dev/doc/release-notes/release-notes-bucash1.5.0.1.md" title="Bitcoin Unlimited Cash Edition 1.5.0.1">
               <ion-icon name="link"></ion-icon> Bitcoin Unlimited Cash Edition 1.5.0.1
           </a>


### PR DESCRIPTION
From the BCHD 0.14.0 Release notes:

This release adds full support for May 15th BCH upgrade including a custom Go schnorr signature implementation and the clean stack exemption.