### PR TITLE
Currency formatting update

### DIFF
--- a/js/ticker.js
+++ b/js/ticker.js
@@ -24,6 +24,11 @@ ticker = function(currencies) {
 
       $.each(currencyRates, function (currency, price) {
         var sym = symbols[currency];
+        if (currency == 'JPY' || currency == 'CNY') {
+          price = Math.floor(price).toLocaleString();
+        } else {
+          price = price.toFixed(2);
+        }
         if (sym === undefined) {
           sym = "";
         }
@@ -40,4 +45,3 @@ ticker = function(currencies) {
 }
 
 ticker(ticker_currencies);
-


### PR DESCRIPTION
Wanted to make CNY and JPY look a bit more normal as Yen is rarely displayed with decimals. But does often have thousandths separators.

![image](https://user-images.githubusercontent.com/3764321/55667690-96387100-589a-11e9-919e-fd6c9f4c3bb8.png)
