### PR TITLE
add cashaccounts to protocols.csv

### DIFF
--- a/etc/protocols.csv
+++ b/etc/protocols.csv
@@ -20,6 +20,7 @@ Prefix,DisplayName,Authors,BitcoinAddress,SpecificationUrl,TxidRedirectUrl
 0x00626368,BChan,BChan Developers,bitcoincash:qqcash37qskcqn2jm2qlkgts5ju7lh9ft5v59l7005,https://bchan.cash/spec,https://bchan.cash/txid/{txid}
 0x006d7367,Cashslide,Cashslide Devs,bitcoincash:qqcash37qskcqn2jm2qlkgts5ju7lh9ft5v59l7005,messages.bch.sx,messages.bch.sx/message/{txid}
 0x00746C6B,Keyport,Keyport,,https://keyport.io,
+0x01010101,Cash Accounts,Jonathan Silverblood,,https://gitlab.com/cash-accounts/specification
 0x02446365,SatoshiDICE,Jon Bestman,bitcoincash:qz9cq5m250zxqfvvm2p5hp4yv7rung4shukgcguxjd,https://satoshidice.com,
 0x04008080,BCH-DNS,BCHDNS Devs,bitcoincash:qqcash37qskcqn2jm2qlkgts5ju7lh9ft5v59l7005,https://domains.bch.sx,https://domains.bch.sx/whois/{txid}
 0x054c5638,TokenGroups,Bitcoin Unlimited,bitcoincash:pq6snv5fcx2fp6dlzg7s0m9zs8yqh74335tzvvfcmq,,


### PR DESCRIPTION
There has been an open issue for this for half a year, this should be maintained more to not discourage people from registering their protocol prefixes, which pretty much no one has done since it was taken over by you guys.