### PR TITLE
Update "Compatible Implementations" list

### DIFF
--- a/_includes/home/header.html
+++ b/_includes/home/header.html
@@ -27,7 +27,6 @@
           <a href="https://github.com/gcash/bchd/releases/tag/v0.14.2" title="BCHD 0.14.2" target="_blank">
               <ion-icon name="link"></ion-icon> BCHD 0.14.2
           </a>
-          </a>
           <a href="https://github.com/bitprim/bitprim/releases/tag/v0.19.0" title="Bitprim 0.19.0" target="_blank">
               <ion-icon name="link"></ion-icon> Bitprim 0.19.0
           </a>

--- a/_includes/home/header.html
+++ b/_includes/home/header.html
@@ -21,16 +21,20 @@
       </div>
         <div class="col-sm-12 col-md-6 text-center reminder-links">
           <h4>{% t 'networkupgrade.compatible' %}:</h4>
-          <a href="https://download.bitcoinabc.org/0.19.2/" title="Bitcoin ABC 0.19.2" target="_blank">
-              <ion-icon name="link"></ion-icon> Bitcoin ABC 0.19.2
+          <a href="https://download.bitcoinabc.org/0.19.4/" title="Bitcoin ABC 0.19.4" target="_blank">
+              <ion-icon name="link"></ion-icon> Bitcoin ABC 0.19.4
           </a>
-          <a href="https://github.com/gcash/bchd/releases/tag/v0.14.0" title="BCHD 0.14.0" target="_blank">
-              <ion-icon name="link"></ion-icon> BCHD 0.14.0
+          <a href="https://github.com/gcash/bchd/releases/tag/v0.14.2" title="BCHD 0.14.2" target="_blank">
+              <ion-icon name="link"></ion-icon> BCHD 0.14.2
           </a>
-          <!-- <a href="https://github.com/BitcoinUnlimited/BitcoinUnlimited/blob/dev/doc/release-notes/release-notes-bucash1.5.0.1.md" title="Bitcoin Unlimited Cash Edition 1.5.0.1">
-              <ion-icon name="link"></ion-icon> Bitcoin Unlimited Cash Edition 1.5.0.1
           </a>
-          <a href="https://github.com/bitcoinxt/bitcoinxt/releases/tag/v0.11K" title="Bitcoin XT Release K">
+          <a href="https://github.com/bitprim/bitprim/releases/tag/v0.19.0" title="Bitprim 0.19.0" target="_blank">
+              <ion-icon name="link"></ion-icon> Bitprim 0.19.0
+          </a>
+          <a href="https://github.com/BitcoinUnlimited/BitcoinUnlimited/releases/tag/bucash1.6.0.0" title="Bitcoin Unlimited Cash Edition 1.6.0.0">
+              <ion-icon name="link"></ion-icon> Bitcoin Unlimited Cash Edition 1.6.0.0
+          </a>
+          <!-- <a href="https://github.com/bitcoinxt/bitcoinxt/releases/tag/v0.11K" title="Bitcoin XT Release K">
               <ion-icon name="link"></ion-icon> Bitcoin XT Release K
           </a>
           <a href="https://github.com/bcoin-org/bcash/blob/master/CHANGELOG.md#v110" title="bcoin bcash" target="_blank">


### PR DESCRIPTION
Add Bitprim and Bitcoin Unlimited
Bump version for Bitcoin ABC and BCHD

This supersedes https://github.com/bitcoincashorg/bitcoincash.org/pull/332