### PR TITLE
Add Silico Signing Protocol

### DIFF
--- a/etc/protocols.csv
+++ b/etc/protocols.csv
@@ -14,6 +14,7 @@ Prefix,DisplayName,Authors,BitcoinAddress,SpecificationUrl,TxidRedirectUrl
 0x004F5243,Oracle Data,Emil Oldenburg,,https://oracle.bitcoin.com,
 0x00504642,BitcoinFiles,SLP devs,bitcoincash:qq2p8mu0gmxfzva2g36kh70efp8hx7qg7qw8m556e8, http://bitcoinfiles.com,
 0x00504c53,Simple Ledger Protocol,SLP devs,bitcoincash:qq2p8mu0gmxfzva2g36kh70efp8hx7qg7qw8m556e8,http://simpleledger.cash/,
+0x005171C0,Silico Signing Protocol,"Jérôme Hauss, Sébastien Madani, Michel Fages",bitcoincash:qzlaquymmc65l74dee3ezm5rxslht8lync26n3q9sk,http://silico.fr/blockchain/bch/silico_signing_protocol.html,
 0x00544542,ChainBet,Jonald Fyookball,,https://github.com/fyookball/ChainBet,
 0x00555354,UniSOT,Stephan Nilsson,bitcoincash:qq8f2kk556x5hhdhr6fqnfdsy020yecs4y00thetwk,http://unisot.io/ust,
 0x00584350,Counterparty Cash,Counterparty Cash Association (CCA),bitcoincash:qprul4s8shr0d9sflfqtjv5y4esgg4k2dcz0eyvscy,https://counterparty.cash,


### PR DESCRIPTION
I wanted to get hashes stored in the Bitcoin Cash blockchain, with a simple structure instead of just plain OP_RETURN text. I did not find an adapted existing protocol following the [OP_RETURN prefix guideline](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/op_return-prefix-guideline.md#lokad-4-byte-prefix-guideline-for-op_return-on-bitcoin-cash).
Here is the protocol I am proposing.

Just added the new line in the protocol.csv file.

The attached file will soon be available on our website.
[silico_signing_protocol.zip](https://github.com/bitcoincashorg/bitcoincash.org/files/3116765/silico_signing_protocol.zip)

