### PR TITLE
Remove Bitcoin XT

### DIFF
--- a/_includes/nodes/nodes.html
+++ b/_includes/nodes/nodes.html
@@ -14,9 +14,6 @@
                 <a href="https://www.bitcoinunlimited.info/download" target="_blank"><img alt="Bitcoin Unlimited" src="/img/wallets/bitcoinunlimited.png"></a>
             </div>
             <div class="col-sm-6 col-md-6 vertical-align to-animate">
-                <a href="https://bitcoinxt.software/" target="_blank"><img alt="BitcoinXT" src="/img/wallets/bitcoinxt.png"></a>
-            </div>
-            <div class="col-sm-6 col-md-6 vertical-align to-animate">
                 <a href="https://github.com/paritytech/parity-bitcoin/" target="_blank"><img alt="Parity Bitcoin" src="/img/wallets/parity.png"></a>
             </div>
             <div class="col-sm-6 col-md-6 vertical-align to-animate">


### PR DESCRIPTION
Bitcoin XT developers have announced that they will not be implementing the upgrade, and that the software should be considered obsolete as-of May 15th.

https://honest.cash/dgenr8/xt-wont-follow-may-19-bch-fork-4313