### PR TITLE
Updated R-prime spec for minor pedantism.

### DIFF
--- a/spec/2019-05-15-schnorr.md
+++ b/spec/2019-05-15-schnorr.md
@@ -88,7 +88,7 @@ In detail, the Schnorr signature verification algorithm takes byte string `m`, p
 4. Let `BP` be the 33-byte encoding of *P* as a compressed point.
 5. Let `Br` be the 32-byte encoding of *r* as an unsigned big-endian 256-bit integer.
 6. Compute integer *e* = *H*(`Br | BP | m`) mod *n*. Here `|` means byte-string concatenation and function *H*() takes the SHA256 hash of its 97-byte input and returns it decoded as a big-endian unsigned integer.
-7. Compute elliptic curve point *R*' = *sG* + (-*e*)*P*, where *G* is the secp256k1 generator point.
+7. Compute elliptic curve point *R*' = *sG* - *eP*, where *G* is the secp256k1 generator point.
 8. Fail if *R*' is the point at infinity.
 9. Fail if the X coordinate of *R*' is not equal to *r*.
 10. Fail if the Jacobi symbol of the Y coordinate of *R*' is not 1.


### PR DESCRIPTION
    In the formula for R', e cannot be negative when multiplying by P.
    Instead, e should multiplied with P, the result then negated, and
    added to sG.