### PR TITLE
Segwit recovery clarifications about script execution and consequences.

### DIFF
--- a/spec/2019-05-15-segwit-recovery.md
+++ b/spec/2019-05-15-segwit-recovery.md
@@ -30,7 +30,7 @@ Equivalently, a witness program can be identified by examining the length and th
 * The first byte is 0x00, or in the range 0x51 – 0x60. (OP_0, or OP_1 – OP_16).
 * The second byte is equal to to the redeem script byte-length, minus two.
 
-All witness-like scripts will be considered valid, even if their execution would normally result in an invalid transaction (e.g. due to a zero value on the stack).  Note that because the witness program contains only push operations (among other restrictions), the P2SH script matching the provided hash is the only meaningful validation criteria.  The only consequence of this specification is that an intentionally unspendable script resembling a witness program may now be spendable.
+All witness-like scripts will be considered valid, even if their execution would normally result in an invalid transaction (e.g. due to a zero value on the stack). Note that because the witness program contains only push operations (among other restrictions), the P2SH script matching the provided hash is the only meaningful validation criteria. The only consequence of this specification is that an intentionally unspendable script resembling a witness program may now be spendable.
 
 This exemption should not be applied for the acceptance of transactions from network peers (i.e., only to acceptance of new blocks), so that segwit recovery transactions remain non-standard (and thus require a miner's cooperation to perform).
 

--- a/spec/2019-05-15-segwit-recovery.md
+++ b/spec/2019-05-15-segwit-recovery.md
@@ -1,9 +1,9 @@
 ---
 layout: specification
 title: 2019-MAY-15 Segwit Recovery Specification
-date: 2019-04-16
+date: 2019-05-13
 activation: 1557921600
-version: 0.3
+version: 0.4
 ---
 
 Segwit Recovery Specification
@@ -29,6 +29,8 @@ Equivalently, a witness program can be identified by examining the length and th
 * The redeem script byte-length is at least 4 and at most 42.
 * The first byte is 0x00, or in the range 0x51 – 0x60. (OP_0, or OP_1 – OP_16).
 * The second byte is equal to to the redeem script byte-length, minus two.
+
+All witness-like scripts will be considered valid, even if their execution would normally result in an invalid transaction (e.g. due to a zero value on the stack).  Note that because the witness program contains only push operations (among other restrictions), the P2SH script matching the provided hash is the only meaningful validation criteria.  The only consequence of this specification is that an intentionally unspendable script resembling a witness program may now be spendable.
 
 This exemption should not be applied for the acceptance of transactions from network peers (i.e., only to acceptance of new blocks), so that segwit recovery transactions remain non-standard (and thus require a miner's cooperation to perform).
 


### PR DESCRIPTION
After much discussion in the Bitcoin ABC telegram dev channel, and additional internal discussion within the Software Verde team, we evaluated the consequence of ignoring the result of a Segwit-Program's P2SH script (compared to running it as a P2SH script and checking its result normally).

I think everyone is in agreement that there is very little consequence/benefit to reverting the change. 
 Therefore, we agree it's more beneficial to ensure the specification is explicit in its intended behavior (when had already been done at least once around mid-April).  We've attempted to clarify the specification so that other implementors clearly know that the regular P2SH result of a Segwit-Program must be ignored in order to remain in sync with the protocol.  We have also briefly included justification for why this is a safe development decision.

Our proposed changes do not alter the implementation, and no code changes should be required for those following the specification's intent.  Our changes merely act as further clarification and justification for future readers.