### PR TITLE
Removing Slack channel

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -35,11 +35,6 @@
                         </a>
                     </li>
                     <li>
-                        <a class="" href="https://btcforks.slack.com/" target="_blank">
-                            <ion-icon name="logo-slack"></ion-icon>
-                        </a>
-                    </li>
-                    <li>
                         <a class="" href="https://www.facebook.com/bitcoincashorg/" target="_blank">
                             <ion-icon name="logo-facebook"></ion-icon>
                         </a>

--- a/_includes/home/about.html
+++ b/_includes/home/about.html
@@ -104,9 +104,6 @@
                     <a class="btn btn-default large round" href="http://reddit.com/r/bitcoincash" target="_blank">
                         <ion-icon name="logo-reddit"></ion-icon> /r/bitcoincash
                     </a>
-                    <a class="btn btn-default large round" href="https://btcforks.slack.com/" target="_blank">
-                        <ion-icon name="logo-slack"></ion-icon> Slack
-                    </a>
                     <a class="btn btn-default large round" href="https://www.facebook.com/bitcoincashorg/" target="_blank">
                         <ion-icon name="logo-facebook"></ion-icon> Facebook
                     </a>


### PR DESCRIPTION
Removing Slack based on discussion that invites are limited to 30 days and then expire + channel is inactive.