### PR TITLE
Fixed donation widget for alt languages

### DIFF
--- a/_includes/footer-scripts.html
+++ b/_includes/footer-scripts.html
@@ -9,7 +9,7 @@
 <script src="/js/bootstrap.min.js"></script>
 <script src="/js/jquery.waypoints.min.js"></script>
 <script src="/js/main.js"></script>
-<script src="js/thermometer2.js"></script>
+<script src="/js/thermometer2.js"></script>
 <script>
     $(document).ready(function(){
         // Add minus icon for collapse element which is open by default


### PR DESCRIPTION
Donation widget does not work for languages other than English as the corresponding JS file is not loaded properly:
<img width="608" alt="Screenshot 2019-06-03 at 23 25 18" src="https://user-images.githubusercontent.com/21960643/58818018-4fc38080-8657-11e9-8d1c-4416fc2afbbf.png">