### PR TITLE
Fix QR code in donation widget

### DIFF
--- a/css/thermometer.css
+++ b/css/thermometer.css
@@ -115,9 +115,9 @@
 }
 
 .qr-codes {
-  width: 100%;
-  max-width: 100px;
-  margin: 0px 0 10px;
+width: 100px;
+height: 100px;
+margin: 0 0 10px 0;
 }
 
 .donation-address {

--- a/css/thermometer.css
+++ b/css/thermometer.css
@@ -115,9 +115,9 @@
 }
 
 .qr-codes {
-width: 100px;
-height: 100px;
-margin: 0 0 10px 0;
+  width: 100px;
+  height: 100px;
+  margin: 0 0 10px 0;
 }
 
 .donation-address {


### PR DESCRIPTION
It was getting stretched out on some Chrome browsers. This fixes it.