### PR TITLE
Remove Parity Node

### DIFF
--- a/_includes/nodes/nodes.html
+++ b/_includes/nodes/nodes.html
@@ -14,9 +14,6 @@
                 <a href="https://www.bitcoinunlimited.info/download" target="_blank"><img alt="Bitcoin Unlimited" src="/img/wallets/bitcoinunlimited.png"></a>
             </div>
             <div class="col-sm-6 col-md-6 vertical-align to-animate">
-                <a href="https://github.com/paritytech/parity-bitcoin/" target="_blank"><img alt="Parity Bitcoin" src="/img/wallets/parity.png"></a>
-            </div>
-            <div class="col-sm-6 col-md-6 vertical-align to-animate">
                 <a href="https://www.bitprim.org/" target="_blank"><img alt="Bitprim" src="/img/wallets/bitprim.png"></a>
             </div>
             <div class="col-sm-6 col-md-6 vertical-align to-animate">


### PR DESCRIPTION
As far as I can tell, the BCH portion in unmaintained, and does not seem to have implemented the last upgrade.