### PR TITLE
Fixed docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,9 @@
-version: '2'
-
+version: '2.4'
 services:
-    webserver:
-      context: .
-      build: ./docker
-      image: bitcoincash:latest
-      ports: 
-        - 8888:80
-      volumes:
-        - /usr/share/nginx/html/
-  
+  bitcoin-cash-org:
+    build: .
+    image: bitcoin-cash-org:latest
+    ports:
+      - '8080:80'
+    volumes:
+      - /usr/share/nginx/html/


### PR DESCRIPTION
This patch does the following:
* Makes version number explicit so that certain versions of docker-compose do not puke on this config.
* Makes the service name explicit so this docker-compose can be used in a multi-project deployment environment without unnecessary changes.
* Cleans up unnecessary fields.