### PR TITLE
[spec] Remove DRAFT warning from Nov 15 upgrade spec

### DIFF
--- a/spec/2019-11-15-upgrade.md
+++ b/spec/2019-11-15-upgrade.md
@@ -1,12 +1,10 @@
 ---
 layout: specification
 title: 2019-NOV-15 Network Upgrade Specification
-date: 2019-08-07
+date: 2019-10-23
 activation: 1573819200
-version: 0.3 DRAFT SUBJECT TO CHANGE
+version: 0.4
 ---
-
-**Important: This document is an in-progress draft, and may change prior to the 2019-11-15 upgrade**
 
 ## Summary
 


### PR DESCRIPTION
This warning is not needed anymore