### PR TITLE
menu: fix links on non-root paths

### DIFF
--- a/_includes/main-menu.html
+++ b/_includes/main-menu.html
@@ -6,22 +6,22 @@
       <div id="navbar" class="navbar-collapse collapse">
         <ul class="nav navbar-nav navbar-right homepage">
           <li>
-            <a href="index.html" class="external">
+            <a href="/index.html" class="external">
               <span>{% t sections.home %}</span>
             </a>
           </li>
           <li>
-            <a href="start-here.html" class="external">
+            <a href="/start-here.html" class="external">
               <span>{% t 'sections.starthere' %}</span>
             </a>
           </li>
           <li>
-            <a href="wallets.html" class="external">
+            <a href="/wallets.html" class="external">
               <span>{% t 'sections.wallets' %}</span>
             </a>
           </li>
           <li>
-            <a href="graphics.html" class="external">
+            <a href="/graphics.html" class="external">
               <span>{% t 'sections.graphics' %}</span>
             </a>
           </li>
@@ -33,29 +33,29 @@
                   <div class="dropdown__content col-md-{%- t 'misc.dropdown_md_width' %} col-sm-{%- t 'misc.dropdown_sm_width' -%}">
                     <ul class="menu-vertical">
                       <li>
-                        <a href="services.html" class="external">
+                        <a href="/services.html" class="external">
                           {% t 'sections.services' %}
                         </a>
                       </li>
 
 
                       <li>
-                        <a href="projects.html" class="external">
+                        <a href="/projects.html" class="external">
                           {% t 'sections.projects' %}
                         </a>
                       </li>
                       <li>
-                        <a href="exchanges.html" class="external">
+                        <a href="/exchanges.html" class="external">
                           {% t 'sections.exchanges' %}
                         </a>
                       </li>
                       <li>
-                        <a href="nodes.html" class="external">
+                        <a href="/nodes.html" class="external">
                           <span>{% t 'sections.nodes' %}</span>
                         </a>
                       </li>
                       <li>
-                        <a href="developers.html" class="external">
+                        <a href="/developers.html" class="external">
                           {% t 'sections.developers' %}
                         </a>
                       </li>
@@ -66,7 +66,7 @@
             </div>
           </li>
           <li>
-            <a href="faq.html" class="external">
+            <a href="/faq.html" class="external">
               <span>{% t 'sections.faq' %}</span>
             </a>
           </li>


### PR DESCRIPTION
reproduce: go to https://www.bitcoincash.org/specs/ and select any option from menu, produces 404

I did not check if this problem occurs anywhere else. I just encountered it while browsing the site.