### PR TITLE
Remove upgrade-complete banner

### DIFF
--- a/_includes/home/header.html
+++ b/_includes/home/header.html
@@ -1,16 +1,3 @@
-<div class="reminder-bar">
- <div class="panel-default container">
-  <div class="row">
-      <h4 class="panel-title">
-          <a>
-            <ion-icon name="checkmark"></ion-icon>
-            {% t 'networkupgrade.completedescription' %}
-          </a>
-      </h4>
-  </div>
- </div>
-</div>
-
 <section id="fh5co-home" data-section="home" class="home site-header">
   <div class="container">
     <div class="row">


### PR DESCRIPTION
It's been a while since the upgrade, so let's remove the "Upgrade Complete" banner.