### PR TITLE
Fix specs

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -181,8 +181,7 @@ learn:
     title: "tutorials"
     description: "Step by step guides to take you from basics to professional grade apps"
 specs:
-  title: "Bitcoin Cash Developer Portal"
-  description: "The following is a topical list of Bitcoin Cash Development Workgroups. Each group should be focused around a specific subject. They may exist for a limited time, or be of ongoing interest."
+  title: "Bitcoin Cash Specifications"
   sections:
     home: "Home"
     workgroups: "Workgroups"

--- a/_includes/main-menu.html
+++ b/_includes/main-menu.html
@@ -31,7 +31,7 @@
               <div class="container">
                 <div class="row">
                   <div class="dropdown__content col-md-{%- t 'misc.dropdown_md_width' %} col-sm-{%- t 'misc.dropdown_sm_width' -%}">
-                    <ul class="menu-vertical">
+                    <ul class="menu-vertical list-unstyled">
                       <li>
                         <a href="services.html" class="external">
                           {% t 'sections.services' %}

--- a/_includes/specs/header.html
+++ b/_includes/specs/header.html
@@ -1,20 +1,20 @@
 <section id="fh5co-home" data-section="home" class="site-header subpage-header">
-    <div class="container">
-        <div class="text-wrap">
-            <div class="text-inner">
-                <div class="row">
-                    <div class="col-md-8 col-md-offset-2">
-                        <h1 class="to-animate">{% t 'specs.title' %}</h1>
-                        <h2 class="to-animate">{% t 'specs.description' %}</h2>
-                    </div>
-                </div>
-            </div>
+  <div class="container">
+    <div class="text-wrap">
+      <div class="text-inner">
+        <div class="row">
+          <div class="col-md-8 col-md-offset-2">
+            <h1 class="to-animate">{% t 'specs.specifications.title' %}</h1>
+            <h2>{% t 'specs.specifications.description' %}</h2>
+          </div>
         </div>
+      </div>
     </div>
-    <div class="slant"></div>
+  </div>
+  <div class="slant"></div>
 </section>
 
 {% comment %}If someone knows a better way to do this, please do {% endcomment %}
 {% for menu in page.submenus %}
-    {% include {{ menu }}/menu.html %}
+  {% include {{ menu }}/menu.html %}
 {% endfor %}

--- a/_includes/specs/specifications.html
+++ b/_includes/specs/specifications.html
@@ -1,31 +1,22 @@
+<section></section>
 <section id="fh5co-specifications" data-section="specifications">
-    <div class="container">
-        <div class="row">
-            <div class="col-md-12 section-heading text-center">
-                <h2 class="to-animate">{% t 'specs.specifications.title' %}</h2>
-                <div class="row">
-                    <div class="col-md-8 col-md-offset-2 subtext to-animate">
-                        <h3>{% t 'specs.specifications.description' %}</h3>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-                {% assign items_group = site.pages | where_exp:"page","page.category == 'spec'" | sort: 'activation' | reverse | group_by: 'activation' %}
-                {% assign date_now = "now" | date: "%Y-%m-%d" %}
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        {% assign items_group = site.pages | where_exp:"page","page.category == 'spec'" | sort: 'activation' | reverse | group_by: 'activation' %}
+        {% assign date_now = "now" | date: "%Y-%m-%d" %}
 
-                {% for group in items_group  %}
-                    {% if group.name != '' %}
-                        <h2>{{group.name | date: "%B %Y"}} Upgrade</h2>
-                        {% assign items = group.items | sort: 'date' | reverse %}
+        {% for group in items_group  %}
+        {% if group.name != '' %}
+        <h2>{{group.name | date: "%B %Y"}} Upgrade</h2>
+        {% assign items = group.items | sort: 'date' | reverse %}
 
-                        {% for item in items %}
-                            <h3><a href="..{{item.url}}">{{item.title}}</a></h3>
-                        {% endfor %}
-                    {% endif %}
-                {% endfor %}
-            </div>
-        </div>
+        {% for item in items %}
+        <h3><a href="..{{item.url}}">{{item.title}}</a></h3>
+        {% endfor %}
+        {% endif %}
+        {% endfor %}
+      </div>
     </div>
+  </div>
 </section>

--- a/_layouts/specification.html
+++ b/_layouts/specification.html
@@ -20,8 +20,6 @@ layout: page
     <div class="slant"></div>
   </section>
 
-{% include specs/menu.html %}
-
 <section class="space--xxs border-bottom specification" id="nodes-section" data-section="nodes">
 	<div class="container">
 		<div class="row">

--- a/css/theme.css
+++ b/css/theme.css
@@ -159,8 +159,7 @@ table,
 blockquote {
   margin-bottom: 1.85714286em;
 }
-ul,
-ol {
+.list-unstyled {
   list-style: none;
   line-height: 1.85714286em;
 }

--- a/spec/2018-nov-upgrade.md
+++ b/spec/2018-nov-upgrade.md
@@ -2,6 +2,7 @@
 layout: specification
 title: 2018 November 15 Network Upgrade Specification
 date: 2018-10-10
+category: spec
 activation: 1542300000
 version: 0.5
 ---

--- a/spec/2019-05-15-schnorr.md
+++ b/spec/2019-05-15-schnorr.md
@@ -2,6 +2,7 @@
 layout: specification
 title: 2019-MAY-15 Schnorr Signature specification
 date: 2019-02-15
+category: spec
 activation: 1557921600
 version: 0.5
 author: Mark B. Lundeberg

--- a/spec/2019-05-15-segwit-recovery.md
+++ b/spec/2019-05-15-segwit-recovery.md
@@ -2,6 +2,7 @@
 layout: specification
 title: 2019-MAY-15 Segwit Recovery Specification
 date: 2019-05-13
+category: spec
 activation: 1557921600
 version: 0.4
 ---

--- a/spec/2019-05-15-upgrade.md
+++ b/spec/2019-05-15-upgrade.md
@@ -2,6 +2,7 @@
 layout: specification
 title: 2019-MAY-15 Network Upgrade Specification
 date: 2019-02-28
+category: spec
 activation: 1557921600
 version: 0.5
 ---

--- a/spec/2019-11-15-minimaldata.md
+++ b/spec/2019-11-15-minimaldata.md
@@ -2,6 +2,7 @@
 layout: specification
 title: 2019-NOV-15 minimal push and minimal number encoding rules
 date: 2019-08-11
+category: spec
 activation: 1573819200
 version: 1.0
 author: Mark B. Lundeberg

--- a/spec/2019-11-15-schnorrmultisig.md
+++ b/spec/2019-11-15-schnorrmultisig.md
@@ -2,6 +2,7 @@
 layout: specification
 title: 2019-NOV-15 Schnorr OP_CHECKMULTISIG specification
 date: 2019-08-11
+category: spec
 activation: 1573819200
 version: 1.0
 author: Mark B. Lundeberg

--- a/spec/2019-11-15-upgrade.md
+++ b/spec/2019-11-15-upgrade.md
@@ -2,6 +2,7 @@
 layout: specification
 title: 2019-NOV-15 Network Upgrade Specification
 date: 2019-10-23
+category: spec
 activation: 1573819200
 version: 0.4
 ---

--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -1,6 +1,6 @@
 ---
 layout: specification
-title: BCH JSON RPC Specification
+title: BCH JSON RPC Specification ⚠️ out of date ⚠️
 category: spec
 date: 2018-05-15
 activation: 1501590000

--- a/spec/block.md
+++ b/spec/block.md
@@ -1,6 +1,6 @@
 ---
 layout: specification
-title: Block Spec for Bitcoin Cash
+title: Block Spec for Bitcoin Cash ⚠️ out of date ⚠️
 category: spec
 date: 2017-08-26
 activation: 1515888000

--- a/spec/index.html
+++ b/spec/index.html
@@ -5,5 +5,4 @@ permalink: specs/index.html
 ---
 {% include main-menu.html %}
 {% include specs/header.html %}
-{% include specs/menu.html %}
 {% include specs/specifications.html %}

--- a/spec/transaction.md
+++ b/spec/transaction.md
@@ -1,6 +1,6 @@
 ---
 layout: specification
-title: Transaction Spec for Bitcoin Cash
+title: Transaction Spec for Bitcoin Cash ⚠️ out of date ⚠️
 category: spec
 date: 2017-08-26
 activation: 1515888000

--- a/specs.html
+++ b/specs.html
@@ -1,10 +1,7 @@
 ---
 layout: page
 title: title.specs
-submenus:
-  - specs
 ---
 {% include main-menu.html %}
-{% include specs/menu.html %}
 {% include specs/header.html %}
 {% include specs/specifications.html %}


### PR DESCRIPTION
What was updated:

- Restored bootstrap list styles
- Added `out of date` flags to some specs
- Display 2019 specs
- Removed specs submenu