### PR TITLE
Remove the Infrastructure Funding Plan from 15 May 2020 upgrade

### DIFF
--- a/spec/2020-05-15-upgrade.md
+++ b/spec/2020-05-15-upgrade.md
@@ -1,10 +1,10 @@
 ---
 layout: specification
 title: 2020-MAY-15 Network Upgrade Specification
-date: 2020-03-02
+date: 2020-03-04
 category: spec
 activation: 1589544000
-version: 0.2 (DRAFT)
+version: 1.0
 ---
 
 **Important: This document is an in-progress draft, and may change prior to the 2020-05-15 upgrade**
@@ -17,7 +17,6 @@ Starting from the next block these consensus rules changes will take effect:
 
 * Bitcoin Cash's SigOps counting and limiting system is replaced with a new system, referred to as SigChecks.
 * A new opcode called OP_REVERSEBYTES has been added to the script system.
-* Enforcement of the Infrastructure Funding Plan, subject to activation by [BIP 9](https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki)  miner signalling.
 
 The following are not consensus changes, but are recommended policy changes for Bitcoin Cash implementations:
 
@@ -36,17 +35,6 @@ Details can be found in the [full specification: SigChecks](https://github.com/b
 This new opcode reverses the order of bytes in a string. It can be used to change endianness.
 
 Details can be found in the [full specification: OP_REVERSEBYTES](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/2020-05-15-op_reversebytes.md).
-
-## Infrastructure Funding Plan
-
-The purpose of the Infrastructure Funding Plan (IFP) is to provide funding to development projects working on common Bitcoin Cash infrastructure. If activated, it enforces that 5% of the block reward is spent to one of a set of specified addresses. The IFP has the following features:
-
-* Activation is triggered via [BIP 9](https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki) version bits signalling.
-* Activation is signalled separately for each of the addresses.
-* Activation occurs if, in a 2-week period, 66% (1344 of 2016) of blocks signal the version bits for that address.
-* If activated, the coinbase transaction in each block must contain an output sending 5% of the block reward to one of the activated addresses.
-
-**A more detailed specification of the IFP is in progress**
 
 ## Automatic Replay Protection
 

--- a/spec/2020-05-15-upgrade.md
+++ b/spec/2020-05-15-upgrade.md
@@ -7,8 +7,6 @@ activation: 1589544000
 version: 1.0
 ---
 
-**Important: This document is an in-progress draft, and may change prior to the 2020-05-15 upgrade**
-
 ## Summary
 
 When the median time past [1] of the most recent 11 blocks (MTP-11) is greater than or equal to UNIX timestamp 1589544000,


### PR DESCRIPTION
The funding part of the recently merged PR https://github.com/bitcoincashorg/bitcoincash.org/pull/444/ did not have consensus and was added something like 18 days after feature freeze.

This violates established procedure to not include changes for which there is strong lack of consensus (in fact, there is very vocal disagreement from large parts of the community about the IFP and its implementation in an existing client).