### PR TITLE
remove DRAFT warning from upgrade specification

### DIFF
--- a/spec/2020-05-15-upgrade.md
+++ b/spec/2020-05-15-upgrade.md
@@ -1,13 +1,11 @@
 ---
 layout: specification
 title: 2020-MAY-15 Network Upgrade Specification
-date: 2020-04-10
+date: 2020-04-26
 category: spec
 activation: 1589544000
-version: 0.3 (DRAFT)
+version: 0.4
 ---
-
-**Important: This document is an in-progress draft, and may change prior to the 2020-05-15 upgrade**
 
 ## Summary
 


### PR DESCRIPTION
It is no longer needed.