### PR TITLE
Remove background task when running `make serve`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ run: container
 	docker run -it -p $(PORT):80 $(PROJECT)bitcoincashorg:latest
 
 serve: _config.yml
-	bundle exec jekyll serve &
+	bundle exec jekyll serve


### PR DESCRIPTION
`make serve` runs the server in the background, even though it says stop
it with ctrl+c. This is annoying because the PID constantly changes which
makes it hard to kill the process.