### PR TITLE
Refactor header menu to remove redundant information

### DIFF
--- a/v2/src/components/header/header.js
+++ b/v2/src/components/header/header.js
@@ -3,7 +3,6 @@ import logo from '../../assets/images/bitcoin-cash-logo-white-small.png';
 import { useStaticQuery, graphql } from "gatsby"
 import headerStyles from "./header.module.css"
 import navBarItems from './navBarItems';
-import hamburger from '../../assets/lib/hamburgers.min.css';
 import axios from 'axios';
 import LivePriceWidget from "../liveprice/live-price-widget";
 import Link from '../../global/link';
@@ -15,10 +14,10 @@ window.onscroll = function() {
   var currentScrollPos = window.pageYOffset;
   if (currentScrollPos <= 1000) return;
   if (prevScrollpos > currentScrollPos) {
-    var navBar = document.getElementById("navbar")
+    let navBar = document.getElementById("navbar")
     if (navBar) navBar.style.top = "0";
   } else {
-    var navBar = document.getElementById("navbar")
+    let navBar = document.getElementById("navbar")
     if (navBar) navBar.style.top = "-100px";
   }
   prevScrollpos = currentScrollPos;
@@ -91,9 +90,9 @@ return (
       </div>
 
       <div className={`${headerStyles.headerLinks} topBotomBordersOut`}>
-        {navBarItems.map(headerLink => {
+        {navBarItems.map((headerLink, index) => {
           return headerLink.href ? 
-            externalLink(headerLink.index, headerLink.text, headerLink.href) : headerLink.dropdown
+            externalLink(index, headerLink.text, headerLink.href) : headerLink.dropdown
         })}
       </div>
 

--- a/v2/src/components/header/navBarItems.js
+++ b/v2/src/components/header/navBarItems.js
@@ -2,25 +2,27 @@ import React from 'react';
 import CommunityDropdown, { MobileCommunityDropdown } from "../dropdownButtons/community-dropdown";
 
 const communityDropdownLinks = [
-     {text:"Services", href:"/services.html"},
-     {text:"Projects", href:"/projects.html"},
-     {text:"Exchanges", href:"/exchanges.html"},
-     {text:"Nodes", href:"/nodes.html"},
-     {text:"Developer Portal", href:"/developers.html"},
-     {text: "Whitepaper", href:"/bitcoin.pdf"}
+    {text:"Services", href:"/services.html"},
+    {text:"Projects", href:"/projects.html"},
+    {text:"Exchanges", href:"/exchanges.html"},
+    {text:"Nodes", href:"/nodes.html"},
+    {text:"Developer Portal", href:"/developers.html"},
+    {text: "Whitepaper", href:"/bitcoin.pdf"},
 ]
 
-const navBarItems =[{index:1, text:"Get started", href:"/start-here.html"},
-     {index:2, text:"Wallets", href:"/wallets.html"},
-     {index:3, text:"Logos", href:"/graphics.html"},
-     {dropdown: <CommunityDropdown links={communityDropdownLinks} index={4} key={4} text={"Community"}></CommunityDropdown>, mobileDropdown: <MobileCommunityDropdown links={communityDropdownLinks} text={"Community"} key={4}></MobileCommunityDropdown>},
-     {index:5, text:"About", href:"/faq.html"}];
+const navBarItems =[
+    {text:"Get started", href:"/start-here.html"},
+    {text:"Wallets", href:"/wallets.html"},
+    {text:"Logos", href:"/graphics.html"},
+    {dropdown: <CommunityDropdown links={communityDropdownLinks} index={4} key={4} text={"Community"}></CommunityDropdown>, mobileDropdown: <MobileCommunityDropdown links={communityDropdownLinks} text={"Community"} key={4}></MobileCommunityDropdown>},
+    {text:"About", href:"/faq.html"},
+];
 
 export const footerItems = [
-     {text: "Get Listed", href:"/get-listed.html"},
-     {text: "Privacy Policy", href: "/privacy-policy.html"},
-     {text: "Legal", href:"/legal.html"}
+    {text: "Get Listed", href:"/get-listed.html"},
+    {text: "Privacy Policy", href: "/privacy-policy.html"},
+    {text: "Legal", href:"/legal.html"},
 ]
 
-
 export default navBarItems;
+

--- a/v2/src/global/link.js
+++ b/v2/src/global/link.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link as GatsbyLink } from "gatsby"
+
 // Since DOM elements <a> cannot receive activeClassName
 // and partiallyActive, destructure the prop here and
 // pass it only to GatsbyLink
@@ -29,4 +30,6 @@ const Link = ({ children, to, activeClassName, partiallyActive, ...other }) => {
     </a>
   )
 }
+
 export default Link
+


### PR DESCRIPTION
As  per title. The indices are redundant infos and can only be gotten wrong.

It seems like the dropdown could also benefit from some refactoring, but this will do for now.