### PR TITLE
Fix broken links all over the place

### DIFF
--- a/_includes/main-menu.html
+++ b/_includes/main-menu.html
@@ -3,25 +3,31 @@
   <div class="container">
     <nav class="navbar navbar-default">
       {% include site-logo.html %}
+      {% assign langPrefix = "" %}
+      {% if site.lang != "en" %}
+        {% capture langPrefix %}/{{ site.lang }}{% endcapture %}
+      {% endif %}
       <div id="navbar" class="navbar-collapse collapse">
         <ul class="nav navbar-nav navbar-right homepage">
           <li>
-            <a href="index.html" class="external">
+          </li>
+          <li>
+            <a href="{{ langPrefix }}/index.html" class="external">
               <span>{% t sections.home %}</span>
             </a>
           </li>
           <li>
-            <a href="start-here.html" class="external">
+            <a href="{{ langPrefix }}/start-here.html" class="external">
               <span>{% t 'sections.starthere' %}</span>
             </a>
           </li>
           <li>
-            <a href="wallets.html" class="external">
+            <a href="{{ langPrefix }}/wallets.html" class="external">
               <span>{% t 'sections.wallets' %}</span>
             </a>
           </li>
           <li>
-            <a href="graphics.html" class="external">
+            <a href="{{ langPrefix }}/graphics.html" class="external">
               <span>{% t 'sections.graphics' %}</span>
             </a>
           </li>
@@ -33,29 +39,29 @@
                   <div class="dropdown__content col-md-{%- t 'misc.dropdown_md_width' %} col-sm-{%- t 'misc.dropdown_sm_width' -%}">
                     <ul class="menu-vertical list-unstyled">
                       <li>
-                        <a href="services.html" class="external">
+                        <a href="{{ langPrefix }}/services.html" class="external">
                           {% t 'sections.services' %}
                         </a>
                       </li>
 
 
                       <li>
-                        <a href="projects.html" class="external">
+                        <a href="{{ langPrefix }}/projects.html" class="external">
                           {% t 'sections.projects' %}
                         </a>
                       </li>
                       <li>
-                        <a href="exchanges.html" class="external">
+                        <a href="{{ langPrefix }}/exchanges.html" class="external">
                           {% t 'sections.exchanges' %}
                         </a>
                       </li>
                       <li>
-                        <a href="nodes.html" class="external">
+                        <a href="{{ langPrefix }}/nodes.html" class="external">
                           <span>{% t 'sections.nodes' %}</span>
                         </a>
                       </li>
                       <li>
-                        <a href="developers.html" class="external">
+                        <a href="{{ langPrefix }}/developers.html" class="external">
                           {% t 'sections.developers' %}
                         </a>
                       </li>
@@ -66,7 +72,7 @@
             </div>
           </li>
           <li>
-            <a href="faq.html" class="external">
+            <a href="{{ langPrefix }}/faq.html" class="external">
               <span>{% t 'sections.faq' %}</span>
             </a>
           </li>


### PR DESCRIPTION
This is a long-overdue followup on #437 It fixes broken links in the nav bar for all pages under a path that's not `/` or `/<lang>/` and still preserves the language prefix.