### PR TITLE
Add initial testnet info for Nov 2020 upgrade

### DIFF
--- a/workgroups/wg-testing/2020-05-15_upgrade_testnet.md
+++ b/workgroups/wg-testing/2020-05-15_upgrade_testnet.md
@@ -3,6 +3,8 @@
 
 The May 15, 2020 the Bitcoin Cash network upgrade, and we have discontinued the upgrade testnet.
 
+Please see the [Testing Workgroup](workgroup.md) for information on later Bitcoin Cash network upgrades.
+
 If you had a node running on the upgrade testnet, youcan re-sync to the regular testnet by following these instructions:
 
 1. Stop the running node
@@ -10,15 +12,6 @@ If you had a node running on the upgrade testnet, youcan re-sync to the regular 
 3. Start Bitcoin ABC 0.21.x
 4. `bitcoin-cli -testnet reconsiderblock 000000001be228c2f33f7c612bf30b8670c50ba885bc26856899424c2e8d4b0a`
 5. `bitcoin-cli -testnet invalidateblock 0000000015c702db7c97bbc63441150e3430bb787bff00abd18839d12912c0e2`
-
-## Other services
-
-Miners: to `bitcoincash.gq:19338`
-user: (testnet address) password:(anything)
-
-Electrumx server: `fulcrum.bitcoincash.gq:60002` will follow the bitcoind.
-
-Explorer: http://bitcoincash.gq:3002
 
 ## Communication
 

--- a/workgroups/wg-testing/2020-11-15_upgrade_testnet.md
+++ b/workgroups/wg-testing/2020-11-15_upgrade_testnet.md
@@ -1,0 +1,22 @@
+2020-11-15 Upgrade Testnet
+==========================
+
+The Nov 15, 2020 Bitcoin Cash will undergo a planned network upgrade.
+The purpose of this upgrade testnet will be for testing of the upgrade activation and features.
+
+The upgrade testnet is not yet operational, please check back again later, 
+or check the [Telegram Group](https://t.me/joinchat/DUeWWkYZbVMjvwMTRFlRhw) for news and updates.
+
+## Other services
+
+Miners: to `bitcoincash.gq:19338`
+user: (testnet address) password:(anything)
+
+Electrumx server: `fulcrum.bitcoincash.gq:60002` will follow the bitcoind.
+
+Explorer: http://bitcoincash.gq:3002
+
+## Communication
+
+To communicate and coordinate with other Upgrade Testnet users, you can join the [Testing Workgroup](workgroup.md) and its associated [Telegram Group](https://t.me/joinchat/DUeWWkYZbVMjvwMTRFlRhw).
+

--- a/workgroups/wg-testing/workgroup.md
+++ b/workgroups/wg-testing/workgroup.md
@@ -18,5 +18,5 @@ Discussion related to testing Bitcoin Cash, focused on Upgrades.
 
 # Relevant Documents
 
-Testnet Information for May 2020 Upgrade: [2020-05-15_upgrade_testnet.md](2020-05-15_upgrade_testnet.md)
+Testnet Information for Nov 2020 Upgrade: [2020-11-15_upgrade_testnet.md](2020-11-15_upgrade_testnet.md)
 


### PR DESCRIPTION
Some info is placeholder, but at least this removes outdated info for now.