### PR TITLE
Fixed inconsistency in Python code, simplified names further

### DIFF
--- a/spec/2020-11-15-asert.md
+++ b/spec/2020-11-15-asert.md
@@ -65,12 +65,12 @@ The current block's target bits are calculated by the following algorithm.
 The aserti3-2d algorithm can be described by the following formula:
 
 ```
-next_target = old_target * 2**((time_delta - ideal_block_time * (height_delta + 1)) / halflife)
+next_target = anchor_target * 2**((time_delta - ideal_block_time * (height_delta + 1)) / halflife)
 ```
 
 where:
 
-- `old_target` is the unsigned 256 bit integer equivalent of the `nBits` value in
+- `anchor_target` is the unsigned 256 bit integer equivalent of the `nBits` value in
   the header of the anchor block.
 - `time_delta` is the difference, in signed integer seconds, between the
   timestamp in the header of the current block and the timestamp in the
@@ -95,7 +95,7 @@ block header.
 Python-code, uses Python 3 syntax:
 
 ```python
-def aserti3_2d(
+def next_target_aserti3_2d(
     anchor_height: int,       # height of the anchor block.
     anchor_parent_time: int,  # timestamp (nTime) of the parent of the anchor block.
     anchor_bits: int,         # 'nBits' value of the anchor block.
@@ -103,40 +103,41 @@ def aserti3_2d(
     current_time: int,        # timestamp of the current block.
 ) -> int:                     # 'target' nBits of the current block.
     ideal_block_time = 600    # in seconds
-    halflife = 172800         # 2 days (in seconds)
+    halflife = 172_800        # 2 days (in seconds)
     radix = 2**16             # 16 bits for decimal part of fixed-point integer arithmetic
-    max_bits = 0x1d00ffff    # maximum target in nBits representation
+    max_bits = 0x1d00_ffff    # maximum target in nBits representation
     max_target = bits_to_target(max_bits)  # maximum target as integer
 
-    target_ref = bits_to_target(anchor_bits)
+    anchor_target = bits_to_target(anchor_bits)
     time_delta = current_time - anchor_parent_time
     height_delta = current_height - anchor_height  # can be negative
-    # // is truncating division (__floordiv__) - see note 3 below
+    # `//` is truncating division (int.__floordiv__) - see note 3 below
     exponent = time_delta - ideal_block_time * (height_delta + 1) // halflife
 
-    # Compute equivalent of `num_shifts ← floor(exponent / 2**16)`
+    # Compute equivalent of `num_shifts = math.floor(exponent / 2**16)`
     num_shifts = exponent >> 16
-    exponent = exponent - num_shifts * radix
-    factor = ((195766423245049 * exponent +
-               971821376 * exponent**2 +
-               5127 * exponent**3 +
-               2**47) >> 48) + radix
-    current_target = target_ref * factor
 
-    # Calculate `next_target = floor(next_target * 2**factor)`
+    exponent = exponent - num_shifts * radix
+    factor = ((195_766_423_245_049 * exponent +
+               971_821_376 * exponent**2 +
+               5_127 * exponent**3 +
+               2**47) >> 48) + radix
+    next_target = anchor_target * factor
+
+    # Calculate `next_target = math.floor(next_target * 2**factor)`
     if num_shifts < 0:
-        current_target >>= (-num_shifts)
+        next_target >>= -num_shifts
     else:
         # Implementations should be careful of overflow here (see note 6 below).
-        current_target <<= num_shifts
+        next_target <<= num_shifts
 
-    current_target >>= 16
-    if current_target == 0:
+    next_target >>= 16
+    if next_target == 0:
         return target_to_bits(1)   # hardest valid target
 
-    if current_target > max_target:
+    if next_target > max_target:
         return max_bits            # limit on easiest target
-    return target_to_bits(current_target)
+    return target_to_bits(next_target)
 ```
 
 Note 1: The reference implementations make use of signed integer arithmetic.


### PR DESCRIPTION
There was an inconsistency in the Python code between `current_target` and `next_target`, which has been fixed.

Now the spec only uses three names for different blocks:

* `anchor` for the parent of the fork block, used as reference block.
* `current` for the current best block, parent of `next` block.
* `next` for the block that‘s about to be mined.

This should make it much easier to implement this algorithm for newcomers.