### PR TITLE
Fix logo link to homepage

### DIFF
--- a/_includes/site-logo.html
+++ b/_includes/site-logo.html
@@ -1,6 +1,10 @@
 <div class="navbar-header">
+  {% assign langPrefix = "" %}
+  {% if site.lang != "en" %}
+    {% capture langPrefix %}/{{ site.lang }}{% endcapture %}
+  {% endif %}
   <a href="#" class="js-fh5co-nav-toggle fh5co-nav-toggle" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar"><i></i></a>
-  <a class="navbar-brand" href="index.html">
+  <a class="navbar-brand" href="{{ langPrefix }}/index.html">
     <img src="/img/bitcoin-cash-logo-white-small.png" alt="Bitcoin Cash" class="lightit">
     <img src="/media-kit/6-bitcoin-cash-logo-horizontal-small.png" alt="Bitcoin Cash" class="darkit">
   </a>


### PR DESCRIPTION
This fixes two issues:
1. Nested paths give `/my/path/index.html` instead of `/index.html` as expected.
2. Translated versions of the site do not direct to the translated homepage.