### PR TITLE
Update link to Bitcoin ABC 0.22.0 release

### DIFF
--- a/_includes/upgrade/upgrade.html
+++ b/_includes/upgrade/upgrade.html
@@ -19,7 +19,7 @@
         <div class="row text-center to-animate pt-5">
             <div class="col-xs-12">		
          <p class="question to-animate">{% t 'networkupgrade.compatible' %}:</p>
-         <p class='to-animate'><a href="https://download.bitcoinabc.org/latest/" title="Bitcoin ABC 0.22.x" target="_blank">
+         <p class='to-animate'><a href="https://www.bitcoinabc.org/2020-08-18-bitcoin-abc-0-22-0/" title="Bitcoin ABC 0.22.x" target="_blank">
              <ion-icon name="link"></ion-icon> Bitcoin ABC 0.22.x</a></p>
          <p class="question to-animate">{% t 'networkupgrade.additional' %}:</p>
          <p class='to-animate'><a href="https://www.bitcoincash.org/spec/2020-11-15-upgrade.html" title="Upgrade Specification" target="_blank">


### PR DESCRIPTION
The article has more complete information. Now that it is published, we can link to it.

Built and tested locally, and clicked on links to check them.