### PR TITLE
Fix .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+_site
+.sass-cache
+.tx
+
+v2/.cache
+v2/node_modules
+v2/public

--- a/v2/.dockerignore
+++ b/v2/.dockerignore
@@ -1,3 +1,0 @@
-.cache/
-node_modules/
-public/


### PR DESCRIPTION
The .dockerignore is in the wrong place and missing a few items that are temporary build artifacts specific to the host.