### PR TITLE
Add a way to specify which v2 pages get built and deployed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Optionally build v2 layer
 FROM node:14.8.0-buster-slim as buildv2
 ARG APP_VERSION=1
+ARG APP_ENV=prod
 WORKDIR /work
 
 # Ensure the public dir exists for v1 builds
@@ -10,7 +11,7 @@ RUN if [ "${APP_VERSION}" -eq "2" ]; then npm -g install gatsby-cli ; fi
 COPY v2/package.json v2/package-lock.json ./
 RUN if [ "${APP_VERSION}" -eq "2" ]; then npm install --frozen-lockfile --non-interactive ; fi
 COPY v2 .
-RUN if [ "${APP_VERSION}" -eq "2" ]; then npm run build ; fi
+RUN if [ "${APP_VERSION}" -eq "2" ]; then GATSBY_APP_ENV="${APP_ENV}" npm run build ; fi
 
 # Build v1 layer
 FROM ruby:2.5.1-stretch as buildv1

--- a/v2/gatsby-config.js
+++ b/v2/gatsby-config.js
@@ -25,8 +25,8 @@ module.exports = {
     {
       resolve: "gatsby-source-filesystem",
       options: {
-        name: "images",
-        path: "src/assets/images",
+        name: "jekyll-migration",
+        path: "src/jekyll-migration",
       },
     },
     {

--- a/v2/gatsby-node.js
+++ b/v2/gatsby-node.js
@@ -1,4 +1,5 @@
 const locales = require("./src/i18n/locales")
+const path = require("path")
 
 // Execute some function for each locale of a given page
 const forEachLocale = async (page, fn) => {
@@ -17,6 +18,84 @@ const forEachLocale = async (page, fn) => {
       }
 
       await fn(page, context, localizationParams, localizedPath)
+    })
+  )
+}
+
+const createPageForEachLocale = async (createPage, page) => {
+  await forEachLocale(
+    page,
+    async (page, context, localizationParams, localizedPath) => {
+      createPage({
+        ...page,
+        path: localizedPath,
+        context,
+      })
+    }
+  )
+}
+
+const createRedirectForEachLocale = async (createRedirect, page) => {
+  await forEachLocale(
+    page,
+    async (page, context, localizationParams, localizedPath) => {
+      createRedirect({
+        fromPath: localizedPath,
+        // By default, assume paths of the form `/path/` transform to
+        // v1 paths of the form `/path.html`
+        toPath: localizedPath.replace(/\/$/, "") + ".html",
+        redirectInBrowser: true,
+        isPermanent: false,
+      })
+    }
+  )
+}
+
+exports.createPages = async ({ graphql, actions, reporter }) => {
+  const { createPage, createRedirect } = actions
+
+  // Fetch path info for all pages
+  const result = await graphql(`
+    {
+      allFile(
+        filter: {
+          sourceInstanceName: { eq: "jekyll-migration" }
+          extension: { eq: "js" }
+        }
+      ) {
+        nodes {
+          name
+          relativeDirectory
+          absolutePath
+        }
+      }
+    }
+  `)
+  if (result.errors) {
+    reporter.panicOnBuild("Error while running GraphQL query.")
+    return
+  }
+
+  await Promise.all(
+    result.data.allFile.nodes.map(async node => {
+      let originalPath = "/" + (node.name == "index" ? "" : node.name + "/")
+      if (node.relativeDirectory) {
+        originalPath = "/" + node.relativeDirectory + originalPath
+      }
+
+      const page = {
+        path: originalPath,
+        component: path.resolve(node.absolutePath),
+        context: {},
+      }
+
+      // In production, we redirect in-development v2 pages to v1 equivalent routes.
+      // In non-prod environments, we create all pages and do not redirect.
+      if (process.env.GATSBY_APP_ENV == "prod") {
+        await createRedirectForEachLocale(createRedirect, page)
+      } else {
+        await createPageForEachLocale(createPage, page)
+      }
     })
   )
 }

--- a/v2/src/jekyll-migration/README.md
+++ b/v2/src/jekyll-migration/README.md
@@ -1,0 +1,5 @@
+Put pages in this directory that are a work-in-progress and should not deploy to production.
+In production, these pages will automatically produce a redirect of the form: `/<page-name>/` -> `/<page-name>.html`
+This is to facilitate the migration from Jekyll (v1) to Gatsby (v2), so that any Gatsby pages
+linking to the work-in-progress pages will appropriately redirect to their Jekyll counterparts
+during the transition.


### PR DESCRIPTION
This provides an easy way to turn v2 pages on and off depending on environment. Default behavior is:
* `npm run build` or `npm run develop` will build all v2 pages for easy local development
* `make run` is not affected (v1 only)
* `make run APP_VERSION=2` is not affected (dev environment which includes all v2 pages)

Setting environment is easy: `make run APP_VERSION=2 APP_ENV=prod`
Similarly: `APP_ENV=prod npm run build`
APP_ENV=beta may also be used.

As pages become completed, different environments can have pages toggled and CI will deploy those v2 pages accordingly.