### PR TITLE
Cleanup v2 README

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -1,51 +1,32 @@
-<!-- AUTO-GENERATED-CONTENT:START (STARTER) -->
-<p align="center">
-</p>
-<h1 align="center">
-  Bitcoincash.org
-</h1>
 
-1.  **Start developing.**
+Bitcoincash.org is migrating to [GatsbyJS](https://www.gatsbyjs.com/docs/). If you are new to Gatsby, check out this
+bootcamp tutorial on YouTube: [The Great Gatsby Bootcamp](https://www.youtube.com/watch?v=8t0vNu2fCCM)
 
-    Navigate into your new site’s directory and start it up.
+### Start developing
 
-    ```shell
-    cd my-default-starter/
-    gatsby develop
-    ```
+#### Setup
 
-1.  **Open the source code and start editing!**
+```
+sudo npm install -g gatsby-cli
+npm install
+```
 
-    Your site is now running at `http://localhost:8000`!
+#### Start a development server
 
-    _Note: You'll also see a second link: _`http://localhost:8000/___graphql`_. This is a tool you can use to experiment with querying your data. Learn more about using this tool in the [Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-five/#introducing-graphiql)._
+The server hot-reloads as you make changes.
+```
+npm run develop
+```
 
-1.  **`/node_modules`**: This directory contains all of the modules of code that your project depends on (npm packages) are automatically installed.
+Your site is now running at `http://localhost:8000`!
 
-2.  **`/src`**: This directory will contain all of the code related to what you will see on the front-end of your site (what you see in the browser) such as your site header or a page template. `src` is a convention for “source code”.
+_Note: You'll also see a second link for GraphiQL: _`http://localhost:8000/___graphql`_. This is a tool you can use to experiment with querying your data. Learn more about using this tool in the [Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-five/#introducing-graphiql)._
 
-3.  **`.gitignore`**: This file tells git which files it should not track / not maintain a version history for.
+#### Get ready to submit a patch
 
-4.  **`.prettierrc`**: This is a configuration file for [Prettier](https://prettier.io/). Prettier is a tool to help keep the formatting of your code consistent.
+Before submitting a patch, format your code:
+```
+npm run format
+```
 
-5.  **`gatsby-browser.js`**: This file is where Gatsby expects to find any usage of the [Gatsby browser APIs](https://www.gatsbyjs.org/docs/browser-apis/) (if any). These allow customization/extension of default Gatsby settings affecting the browser.
-
-6.  **`gatsby-config.js`**: This is the main configuration file for a Gatsby site. This is where you can specify information about your site (metadata) like the site title and description, which Gatsby plugins you’d like to include, etc. (Check out the [config docs](https://www.gatsbyjs.org/docs/gatsby-config/) for more detail).
-
-7.  **`gatsby-node.js`**: This file is where Gatsby expects to find any usage of the [Gatsby Node APIs](https://www.gatsbyjs.org/docs/node-apis/) (if any). These allow customization/extension of default Gatsby settings affecting pieces of the site build process.
-
-8.  **`gatsby-ssr.js`**: This file is where Gatsby expects to find any usage of the [Gatsby server-side rendering APIs](https://www.gatsbyjs.org/docs/ssr-apis/) (if any). These allow customization of default Gatsby settings affecting server-side rendering.
-
-9.  **`LICENSE`**: This Gatsby starter is licensed under the 0BSD license. This means that you can see this file as a placeholder and replace it with your own license.
-
-10. **`package-lock.json`** (See `package.json` below, first). This is an automatically generated file based on the exact versions of your npm dependencies that were installed for your project. **(You won’t change this file directly).**
-
-11. **`package.json`**: A manifest file for Node.js projects, which includes things like metadata (the project’s name, author, etc). This manifest is how npm knows which packages to install for your project.
-
-## 💫 Deploy
-
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/gatsbyjs/gatsby-starter-default)
-
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/project?template=https://github.com/gatsbyjs/gatsby-starter-default)
-
-<!-- AUTO-GENERATED-CONTENT:END -->
+See `package.json { scripts: ... }` for other useful scripts.


### PR DESCRIPTION
The README needs to focus on the specifics of this repo. Listing out the different Gatsby or other tools' files is destined to get out of date, and considering length of the list already, it will likely be ignored.  It's best if we point new devs in the right direction so they become familiar with the tools we're using.

This patch also cleans up some cruft so that adding new information is easier and more straight forward.