### PR TITLE
Configure cache for static assets, pages, and page-data

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -48,7 +48,22 @@ server {
 
     root /usr/share/nginx;
     location / {
+        expires 0;
+        add_header Cache-Control "public, must-revalidate";
         try_files /htmlv2/$uri /html/$uri /htmlv2/$uri/index.html /html/$uri/index.html =404;
+    }
+
+    location ^~ /static/ {
+        expires max;
+        add_header Cache-Control "public, immutable";
+        try_files /htmlv2/$uri =404;
+    }
+
+    location ^~ /page-data/ {
+        # page-data.json and app-data.json files shoud be revalidated on every request
+        expires 0;
+        add_header Cache-Control "public, must-revalidate";
+        try_files /htmlv2/$uri /html/$uri =404;
     }
 
     location /robots.txt {


### PR DESCRIPTION
Gatsby provides some nice guidelines for caching: https://www.gatsbyjs.com/docs/caching/
This patch ensures users properly cache assets forever and limits caching of page data, fixing some cache busting issues (often noticeable when translations appear outdated).

Depends on #605 for the cache to work correctly for static assets, but these changes may be landed in any order.