### PR TITLE
Tweaks to announcement bar mobile styling

### DIFF
--- a/v2/src/layout/announcement-bar.module.scss
+++ b/v2/src/layout/announcement-bar.module.scss
@@ -106,6 +106,8 @@
   .accordionTitle {
     margin-right: 0;
     padding: 10px 0;
+    font-size: 12px;
+    display: inline-block;
   }
 
   .accordionTitle svg {
@@ -135,5 +137,10 @@
   .annoucementPanelInner button {
     margin-right: 0;
     width: 100%;
+  }
+
+  .accordionSection {
+    padding: 0px 10px;
+    text-align: center;
   }
 }


### PR DESCRIPTION
Proposing a few css tweaks to improve announcement bar mobile styling in the header. These edits should make it a bit cleaner and not wrap text on most devices 