### PR TITLE
Allow Gatbsy to redirect v1 pages to v2 pages

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -50,6 +50,26 @@ server {
     location / {
         expires 0;
         add_header Cache-Control "public, must-revalidate";
+        try_files /htmlv2/$uri /htmlv2/$uri/index.html =404;
+    }
+
+    location /get-listed.html {
+        try_files /htmlv2/$uri /html/$uri /htmlv2/$uri/index.html /html/$uri/index.html =404;
+    }
+
+    location /privacy-policy.html {
+        try_files /htmlv2/$uri /html/$uri /htmlv2/$uri/index.html /html/$uri/index.html =404;
+    }
+
+    location /legal.html {
+        try_files /htmlv2/$uri /html/$uri /htmlv2/$uri/index.html /html/$uri/index.html =404;
+    }
+
+    location /spec/ {
+        try_files /htmlv2/$uri /html/$uri /htmlv2/$uri/index.html /html/$uri/index.html =404;
+    }
+
+    location /specs/ {
         try_files /htmlv2/$uri /html/$uri /htmlv2/$uri/index.html /html/$uri/index.html =404;
     }
 
@@ -63,7 +83,7 @@ server {
         # page-data.json and app-data.json files shoud be revalidated on every request
         expires 0;
         add_header Cache-Control "public, must-revalidate";
-        try_files /htmlv2/$uri /html/$uri =404;
+        try_files /htmlv2/$uri =404;
     }
 
     location /robots.txt {


### PR DESCRIPTION
This effectively does not route v1 content anymore except for the remaining pages which are not yet v2-complete.
This will allow Gatsby to determine v1 -> v2 redirects.

This change will not disrupt any deployments for v2 content, but in order for v1 to correctly redirect to v2 for the remaining pages, the associated block in nginx.conf will need to removed for that redirect to work correctly. This should only be done
once the v2 page has baked in prod and is considered stable.

**Depends on #611**