### PR TITLE
Add upgrade page

### DIFF
--- a/v2/src/global/upgrade-date.js
+++ b/v2/src/global/upgrade-date.js
@@ -1,0 +1,18 @@
+import { useLocaleContext } from "i18n/provider"
+
+const ACTIVATION_TIMESTAMP = 1605441600
+
+const UpgradeDate = () => {
+  const locale = useLocaleContext()
+  const upgradeTimeStr = new Date(
+    ACTIVATION_TIMESTAMP * 1000
+  ).toLocaleDateString(locale.bcp47, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })
+
+  return upgradeTimeStr
+}
+
+export default UpgradeDate

--- a/v2/src/layout/announcement-bar.js
+++ b/v2/src/layout/announcement-bar.js
@@ -5,20 +5,9 @@ import PrimaryButton from "components/buttons/primary-button"
 import Link from "global/link"
 import { Accordion } from "react-bootstrap"
 import Checkmark from "assets/icons/checkmark.svg"
-import { useLocaleContext } from "i18n/provider"
-
-const ACTIVATION_TIMESTAMP = 1605441600
+import UpgradeDate from "global/upgrade-date.js"
 
 const AnnouncementBar = () => {
-  const locale = useLocaleContext()
-  const upgradeTimeStr = new Date(
-    ACTIVATION_TIMESTAMP * 1000
-  ).toLocaleDateString(locale.bcp47, {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  })
-
   return (
     <Accordion className={S.accordionSection}>
       <Accordion.Toggle as={S.accordionSection} eventKey="0">
@@ -27,7 +16,7 @@ const AnnouncementBar = () => {
           <fbt desc="Annoucement bar reminder headline">
             Reminder:
             <fbt:param name="upgrade activation time">
-              {upgradeTimeStr}
+              <UpgradeDate />
             </fbt:param>
             Planned Network Upgrade
           </fbt>
@@ -40,7 +29,7 @@ const AnnouncementBar = () => {
               <h4>
                 <fbt desc="Annoucement bar inner headline">
                   <fbt:param name="upgrade activation time">
-                    {upgradeTimeStr}
+                    <UpgradeDate />
                   </fbt:param>
                   Planned Network Upgrade
                 </fbt>

--- a/v2/src/pages/upgrade.js
+++ b/v2/src/pages/upgrade.js
@@ -5,88 +5,78 @@ import { Container } from "react-bootstrap"
 import PrimaryButton from "components/buttons/primary-button"
 import Link from "global/link"
 import { useLocaleContext } from "i18n/provider"
-import Style from "./upgrade.scss"
+import S from "./upgrade.module.scss"
 
 const ACTIVATION_TIMESTAMP = 1605441600
 
 const UpgradePage = () => {
-
-  // const locale = useLocaleContext()
-  // const upgradeTimeStr = new Date(
-  //   ACTIVATION_TIMESTAMP * 1000
-  // ).toLocaleDateString(locale.bcp47, {
-  //   year: "numeric",
-  //   month: "short",
-  //   day: "numeric",
-  // })
+  const locale = useLocaleContext()
+  const upgradeTimeStr = new Date(
+    ACTIVATION_TIMESTAMP * 1000
+  ).toLocaleDateString(locale.bcp47, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })
 
   return (
     <>
       <SEO title={fbt("How to Upgrade", "Upgrade page SEO title")} />
-      <Container>
+      <Container className={S.linkcontainer}>
         <h2 className="centerh2">
           <fbt desc="Upgrade page heading">How to Upgrade</fbt>
         </h2>
-              <h4>
-                <fbt desc="Annoucement bar inner headline">
-                  {/* <fbt:param name="upgrade activation time">
-                    {upgradeTimeStr}
-                  </fbt:param> */}
-                  Planned Network Upgrade
-                </fbt>
-              </h4>
-              <p className={Style.panelLink2}>
-               
-                  The Bitcoin Cash network will undergo a protocol upgrade as
-                  per the roadmap. Businesses and individuals who use the
-                  Bitcoin Cash network should check to ensure that their
-                  software is compatible with the upgrade.
-             
-              </p>
-             
-                <PrimaryButton
-                  noMarginLeft={true}
-                  buttonText={fbt(
-                    "See Roadmap",
-                    "'See Roadmap' button of the annoucement bar"
-                  )}
-                  href={"/roadmap/"}
-                />
-              
-          
-              <h4>
-                <fbt desc="Annoucement bar 'Compatible Implementations'">
-                  Compatible Implementations:
-                </fbt>
-              </h4>
-              <Link
-                className={Style.panelLink2}
-                href="https://www.bitcoinabc.org/2020-08-18-bitcoin-abc-0-22-0/"
-              >
-                Bitcoin ABC 0.22.x
-              </Link>
-              <h4>
-                <fbt desc="Annoucement bar 'Additional Information:'">
-                  Additional Information:
-                </fbt>
-              </h4>
-              <Link
-                className={Style.panelLink}
-                href="/spec/2020-11-15-upgrade.html"
-              >
-                <fbt desc="Annoucement bar 'Upgrade Specification'">
-                  Upgrade Specification
-                </fbt>
-              </Link>
-              <Link
-                className={Style.panelLink}
-                href="https://github.com/bitcoincashorg/bitcoincash.org/blob/master/workgroups/wg-testing/2020-11-15_upgrade_testnet.md"
-              >
-                <fbt desc="Annoucement bar 'Testnet Information'">
-                  Testnet Information
-                </fbt>
-              </Link>
-            
+        <h3>{upgradeTimeStr}</h3>
+        <h3>
+          <fbt desc="Annoucement bar inner headline">
+            Planned Network Upgrade
+          </fbt>
+        </h3>
+        <p>
+          The Bitcoin Cash network will undergo a protocol upgrade as per the
+          roadmap. Businesses and individuals who use the Bitcoin Cash network
+          should check to ensure that their software is compatible with the
+          upgrade.
+        </p>
+        <PrimaryButton
+          noMarginLeft={true}
+          buttonText={fbt(
+            "See Roadmap",
+            "'See Roadmap' button of the annoucement bar"
+          )}
+          href={"/roadmap/"}
+        />
+
+        <h4 className={S.header}>
+          <fbt desc="Annoucement bar 'Compatible Implementations'">
+            Compatible Implementations:
+          </fbt>
+        </h4>
+        <Link href="https://www.bitcoinabc.org/2020-08-18-bitcoin-abc-0-22-0/">
+          Bitcoin ABC 0.22.x
+        </Link>
+        <h4 className={S.header}>
+          <fbt desc="Annoucement bar 'Additional Information:'">
+            Additional Information:
+          </fbt>
+        </h4>
+        <Link href="https://blog.bitcoinabc.org/2020/09/14/preparing-businesses-for-a-successful-network-upgrade/">
+          <fbt desc="Upgrade page 'Prepare for the Upgrade' header">
+            Prepare for the Upgrade
+          </fbt>
+        </Link>
+        <br />
+        <Link href="/spec/2020-11-15-upgrade.html">
+          <fbt desc="Annoucement bar 'Upgrade Specification'">
+            Upgrade Specification
+          </fbt>
+        </Link>
+        <br />
+        <Link href="https://github.com/bitcoincashorg/bitcoincash.org/blob/master/workgroups/wg-testing/2020-11-15_upgrade_testnet.md">
+          <fbt desc="Annoucement bar 'Testnet Information'">
+            Testnet Information
+          </fbt>
+        </Link>
       </Container>
     </>
   )

--- a/v2/src/pages/upgrade.js
+++ b/v2/src/pages/upgrade.js
@@ -4,21 +4,10 @@ import SEO from "components/seo"
 import { Container } from "react-bootstrap"
 import PrimaryButton from "components/buttons/primary-button"
 import Link from "global/link"
-import { useLocaleContext } from "i18n/provider"
 import S from "./upgrade.module.scss"
-
-const ACTIVATION_TIMESTAMP = 1605441600
+import UpgradeDate from "global/upgrade-date.js"
 
 const UpgradePage = () => {
-  const locale = useLocaleContext()
-  const upgradeTimeStr = new Date(
-    ACTIVATION_TIMESTAMP * 1000
-  ).toLocaleDateString(locale.bcp47, {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  })
-
   return (
     <>
       <SEO title={fbt("How to Upgrade", "Upgrade page SEO title")} />
@@ -26,11 +15,11 @@ const UpgradePage = () => {
         <h2 className="centerh2">
           <fbt desc="Upgrade page heading">How to Upgrade</fbt>
         </h2>
-        <h3>{upgradeTimeStr}</h3>
         <h3>
-          <fbt desc="Annoucement bar inner headline">
-            Planned Network Upgrade
-          </fbt>
+          <UpgradeDate />
+        </h3>
+        <h3>
+          <fbt desc="Upgrade page subheadline">Planned Network Upgrade</fbt>
         </h3>
         <p>
           The Bitcoin Cash network will undergo a protocol upgrade as per the
@@ -42,13 +31,13 @@ const UpgradePage = () => {
           noMarginLeft={true}
           buttonText={fbt(
             "See Roadmap",
-            "'See Roadmap' button of the annoucement bar"
+            "'See Roadmap' button of the Upgrade page"
           )}
           href={"/roadmap/"}
         />
 
         <h4 className={S.header}>
-          <fbt desc="Annoucement bar 'Compatible Implementations'">
+          <fbt desc="Upgrade page 'Compatible Implementations'">
             Compatible Implementations:
           </fbt>
         </h4>
@@ -56,7 +45,7 @@ const UpgradePage = () => {
           Bitcoin ABC 0.22.x
         </Link>
         <h4 className={S.header}>
-          <fbt desc="Annoucement bar 'Additional Information:'">
+          <fbt desc="Upgrade page 'Additional Information:'">
             Additional Information:
           </fbt>
         </h4>
@@ -67,13 +56,13 @@ const UpgradePage = () => {
         </Link>
         <br />
         <Link href="/spec/2020-11-15-upgrade.html">
-          <fbt desc="Annoucement bar 'Upgrade Specification'">
+          <fbt desc="Upgrade page 'Upgrade Specification'">
             Upgrade Specification
           </fbt>
         </Link>
         <br />
         <Link href="https://github.com/bitcoincashorg/bitcoincash.org/blob/master/workgroups/wg-testing/2020-11-15_upgrade_testnet.md">
-          <fbt desc="Annoucement bar 'Testnet Information'">
+          <fbt desc="Upgrade page 'Testnet Information'">
             Testnet Information
           </fbt>
         </Link>

--- a/v2/src/pages/upgrade.js
+++ b/v2/src/pages/upgrade.js
@@ -1,0 +1,95 @@
+import React from "react"
+import fbt from "fbt"
+import SEO from "components/seo"
+import { Container } from "react-bootstrap"
+import PrimaryButton from "components/buttons/primary-button"
+import Link from "global/link"
+import { useLocaleContext } from "i18n/provider"
+import Style from "./upgrade.scss"
+
+const ACTIVATION_TIMESTAMP = 1605441600
+
+const UpgradePage = () => {
+
+  // const locale = useLocaleContext()
+  // const upgradeTimeStr = new Date(
+  //   ACTIVATION_TIMESTAMP * 1000
+  // ).toLocaleDateString(locale.bcp47, {
+  //   year: "numeric",
+  //   month: "short",
+  //   day: "numeric",
+  // })
+
+  return (
+    <>
+      <SEO title={fbt("How to Upgrade", "Upgrade page SEO title")} />
+      <Container>
+        <h2 className="centerh2">
+          <fbt desc="Upgrade page heading">How to Upgrade</fbt>
+        </h2>
+              <h4>
+                <fbt desc="Annoucement bar inner headline">
+                  {/* <fbt:param name="upgrade activation time">
+                    {upgradeTimeStr}
+                  </fbt:param> */}
+                  Planned Network Upgrade
+                </fbt>
+              </h4>
+              <p className={Style.panelLink2}>
+               
+                  The Bitcoin Cash network will undergo a protocol upgrade as
+                  per the roadmap. Businesses and individuals who use the
+                  Bitcoin Cash network should check to ensure that their
+                  software is compatible with the upgrade.
+             
+              </p>
+             
+                <PrimaryButton
+                  noMarginLeft={true}
+                  buttonText={fbt(
+                    "See Roadmap",
+                    "'See Roadmap' button of the annoucement bar"
+                  )}
+                  href={"/roadmap/"}
+                />
+              
+          
+              <h4>
+                <fbt desc="Annoucement bar 'Compatible Implementations'">
+                  Compatible Implementations:
+                </fbt>
+              </h4>
+              <Link
+                className={Style.panelLink2}
+                href="https://www.bitcoinabc.org/2020-08-18-bitcoin-abc-0-22-0/"
+              >
+                Bitcoin ABC 0.22.x
+              </Link>
+              <h4>
+                <fbt desc="Annoucement bar 'Additional Information:'">
+                  Additional Information:
+                </fbt>
+              </h4>
+              <Link
+                className={Style.panelLink}
+                href="/spec/2020-11-15-upgrade.html"
+              >
+                <fbt desc="Annoucement bar 'Upgrade Specification'">
+                  Upgrade Specification
+                </fbt>
+              </Link>
+              <Link
+                className={Style.panelLink}
+                href="https://github.com/bitcoincashorg/bitcoincash.org/blob/master/workgroups/wg-testing/2020-11-15_upgrade_testnet.md"
+              >
+                <fbt desc="Annoucement bar 'Testnet Information'">
+                  Testnet Information
+                </fbt>
+              </Link>
+            
+      </Container>
+    </>
+  )
+}
+
+export default UpgradePage

--- a/v2/src/pages/upgrade.module.scss
+++ b/v2/src/pages/upgrade.module.scss
@@ -1,0 +1,20 @@
+.header {
+  margin-top: 60px;
+}
+
+.linkcontainer a {
+  color: #444;
+  transition: all 200ms ease-in-out;
+  display: inline-block;
+  margin-bottom: 15px;
+}
+
+.linkcontainer a:hover {
+  color: #ff8d00;
+}
+
+@media (max-width: 760px) {
+  .header {
+    margin-top: 30px;
+  }
+}


### PR DESCRIPTION
Creating v2 page for /upgrade. Carries over same info as legacy page plus additional link to blog post as requested 