### PR TITLE
Fix routing for missing specs v2 page

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -73,7 +73,7 @@ server {
         try_files /htmlv2/$uri /html/$uri /htmlv2/$uri/index.html /html/$uri/index.html =404;
     }
 
-    location /specs/ {
+    location /specs.html {
         try_files /htmlv2/$uri /html/$uri /htmlv2/$uri/index.html /html/$uri/index.html =404;
     }
 

--- a/v2/src/pages/developers.js
+++ b/v2/src/pages/developers.js
@@ -112,7 +112,7 @@ const DevelopersPage = () => {
                   "View More",
                   "View more button on developers page"
                 )}
-                href={"/specs/"}
+                href={"/specs.html"}
               />
             </div>
           </Col>


### PR DESCRIPTION
The `/specs/` page does not exist in Gatsby yet, resulting in broken **internal** links that point at this page. Fortunately, the v1 version of the page is accessible via both `/specs/` and `/specs.html` so we can still use the old style link and still have the same assumptions regarding redirects as all other v1 pages.