### PR TITLE
Remove legacy upgrade page

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -65,10 +65,6 @@ server {
         try_files /htmlv2/$uri /html/$uri /htmlv2/$uri/index.html /html/$uri/index.html =404;
     }
 
-    location /upgrade.html {
-        try_files /htmlv2/$uri /html/$uri /htmlv2/$uri/index.html /html/$uri/index.html =404;
-    }
-
     location /spec/ {
         try_files /htmlv2/$uri /html/$uri /htmlv2/$uri/index.html /html/$uri/index.html =404;
     }


### PR DESCRIPTION
Now that the new upgrade page is up, the legacy version can no longer resolve. 
- removed redirect to legacy page from nginx.conf