### PR TITLE
Typo fix on roadmap page 

### DIFF
--- a/v2/src/pages/roadmap.js
+++ b/v2/src/pages/roadmap.js
@@ -341,7 +341,7 @@ const RoadmapPage = () => {
               This roadmap is intended to provide high-level technical
               direction, and enable different technical teams to work together
               towards a common goal for advancing Bitcoin Cash. The role of
-              developers in furth ering this goal is to produce high-quality
+              developers in furthering this goal is to produce high-quality
               professional software that serves the needs of its users, miners
               and merchants. We strive for continuous technical improvement, to
               produce reliable products providing a solid foundation for Bitcoin


### PR DESCRIPTION
This was a legacy typo that got carried over. Removed the extra space in the word "furthering" on the the roadmap page. 
This will likely break the translations, so will need to rematch this string in transifex with the current translations, but should be fairly easy  