### PR TITLE
[activationtestnet] make example easier to read and copy

### DIFF
--- a/workgroups/wg-testing/2020-11-15_upgrade_testnet.md
+++ b/workgroups/wg-testing/2020-11-15_upgrade_testnet.md
@@ -18,7 +18,10 @@ How to participate in the Scheduled Activation Testnet:
 
 Minimal command-line example to participate in the activation:
 
->bitcoind -testnet -axionactivationtime=**[activation timestamp]** -addnode=**upgrade-node1.bitcoincash.org** -addnode=**upgrade-node2.bitcoincash.org**
+<pre><code>bitcoind -chain=test \
+    -addnode=<b>upgrade-node1.bitcoincash.org</b> \
+    -addnode=<b>upgrade-node2.bitcoincash.org</b> \
+    -axionactivationtime=<b>[activation timestamp]</b></code></pre>
 
 ### Services:
 


### PR DESCRIPTION
easier to read, easier to copy&paste and change the activation timestamp

also changed from old `-testnet` switch to newer style `-chain=test`