### PR TITLE
Announcement bar link fix

### DIFF
--- a/v2/src/layout/announcement-bar.js
+++ b/v2/src/layout/announcement-bar.js
@@ -127,7 +127,7 @@ const AnnouncementBar = () => {
               <p>
                 <fbt desc="Annoucement bar paragraph">
                   The Bitcoin Cash network will undergo a protocol upgrade as
-                  per <Link href="/roadmap/">the roadmap</Link>. Businesses and
+                  per <Link to="/roadmap/">the roadmap</Link>. Businesses and
                   other node operators who use the Bitcoin Cash network should
                   check to ensure that their software is compatible with the
                   upgrade.


### PR DESCRIPTION
This link needs to use "to" instead, otherwise other languages jump to the english page