### PR TITLE
Feature coinomi wallet instead of EC. 

### DIFF
--- a/v2/src/partners/wallets/coinomi.js
+++ b/v2/src/partners/wallets/coinomi.js
@@ -14,7 +14,7 @@ const Coinomi = () => ({
       Windows, macOS and Linux.
     </fbt>
   ),
-  featured: false,
+  featured: true,
   android: true,
   ios: true,
   windows: true,

--- a/v2/src/partners/wallets/electroncash.js
+++ b/v2/src/partners/wallets/electroncash.js
@@ -14,7 +14,6 @@ const ElectronCash = () => ({
       private keys and use them in other Bitcoin Cash clients.
     </fbt>
   ),
-  featured: true,
   android: true,
   ios: true,
   windows: true,


### PR DESCRIPTION
The EC guys do not want to be featured anymore.

Coinomi have been great since the eraly days. One of the first wallets to support Bitcoin Cash and things like CashAddr later on.