### PR TITLE
Clear accessibility linting warnings

### DIFF
--- a/v2/src/layout/navbar.js
+++ b/v2/src/layout/navbar.js
@@ -12,7 +12,13 @@ const NavBar = () => {
   const MobileDropdown = ({ children, links, navLinkClass }) => {
     const [expanded, setExpanded] = useState(false)
     return (
-      <div onClick={() => setExpanded(!expanded)}>
+      <div
+        onClick={() => setExpanded(!expanded)}
+        onKeyDown={() => setExpanded(!expanded)}
+        role="button"
+        tabIndex="0"
+        style={{ outline: "none" }}
+      >
         <div className={navLinkClass}>{children}</div>
         {expanded && (
           <div>
@@ -63,6 +69,10 @@ const NavBar = () => {
             S.nopadding
           }`}
           onClick={() => openMobileMenu(!open)}
+          onKeyDown={() => openMobileMenu(!open)}
+          role="button"
+          tabIndex="0"
+          style={{ outline: "none" }}
         >
           <div className="hamburger-box">
             <div className="hamburger-inner" />

--- a/v2/src/pages/developers.js
+++ b/v2/src/pages/developers.js
@@ -94,7 +94,7 @@ const DevelopersPage = () => {
       </Container>
       <Container>
         <Row>
-          <Col md={6} style={{padding: '10px'}}>
+          <Col md={6} style={{ padding: "10px" }}>
             <div className={S.card}>
               <div className={S.language}>
                 <Check className={S.icons} />
@@ -105,7 +105,7 @@ const DevelopersPage = () => {
               <p>
                 <fbt desc="Developers page, BitCash description">
                   Vocabulary and associated APIs for Bitcoin Cash
-                  </fbt>
+                </fbt>
               </p>
               <PrimaryButton
                 noMarginLeft={true}
@@ -118,7 +118,7 @@ const DevelopersPage = () => {
             </div>
           </Col>
 
-          <Col md={6} style={{padding: '10px'}}>
+          <Col md={6} style={{ padding: "10px" }}>
             <div className={S.card}>
               <div className={S.language}>
                 <Wallet className={S.icons} />
@@ -126,8 +126,8 @@ const DevelopersPage = () => {
               <h3>Web Wallet</h3>
               <p>
                 <fbt desc="Developers page, web wallet description">
-                  An open source web wallet to hack
-                  and white label for your own application.
+                  An open source web wallet to hack and white label for your own
+                  application.
                 </fbt>
               </p>
               <PrimaryButton
@@ -143,7 +143,7 @@ const DevelopersPage = () => {
         </Row>
 
         <Row>
-          <Col md={6} style={{padding: '10px'}}>
+          <Col md={6} style={{ padding: "10px" }}>
             <div className={S.card}>
               <div className={S.language}>
                 <Cog className={S.icons} />
@@ -166,7 +166,7 @@ const DevelopersPage = () => {
             </div>
           </Col>
 
-          <Col md={6} style={{padding: '10px'}}>
+          <Col md={6} style={{ padding: "10px" }}>
             <div className={S.card}>
               <div className={S.language}>
                 <Document className={S.icons} />
@@ -174,8 +174,9 @@ const DevelopersPage = () => {
               <h3>Documentation</h3>
               <p>
                 <fbt desc="Developers page, SLP SDK description">
-                  From basic conecepts to advanced topics, a range of documentation
-                  and videos for developers interested in programmable money.
+                  From basic conecepts to advanced topics, a range of
+                  documentation and videos for developers interested in
+                  programmable money.
                 </fbt>
               </p>
               <PrimaryButton


### PR DESCRIPTION
There have been some accessibility feature warnings that I wanted to address
- added keydown, role, and tabindexes to naviagtion items 
- there were also some formatting fixes that were added to the developers.js file when run format was run  