### PR TITLE
Updating upgrade info

### DIFF
--- a/v2/src/assets/icons/share.svg
+++ b/v2/src/assets/icons/share.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><title>Share</title><path d='M336 192h40a40 40 0 0140 40v192a40 40 0 01-40 40H136a40 40 0 01-40-40V232a40 40 0 0140-40h40M336 128l-80-80-80 80M256 321V48' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='32'/></svg>

--- a/v2/src/layout/announcement-bar.js
+++ b/v2/src/layout/announcement-bar.js
@@ -1,12 +1,12 @@
 import React from "react"
 import fbt from "fbt"
 import S from "./announcement-bar.module.scss"
-import PrimaryButton from "components/buttons/primary-button"
 import Link from "global/link"
 import { Accordion } from "react-bootstrap"
 import Checkmark from "assets/icons/checkmark.svg"
 import UpgradeDate from "global/upgrade-date.js"
 import LinkIcon from "assets/icons/link.svg"
+import ShareIcon from "assets/icons/share.svg"
 import Countdown, { zeroPad } from "react-countdown"
 import { ACTIVATION_TIMESTAMP } from "global/upgrade-date.js"
 import Network from "assets/images/network.png"
@@ -92,11 +92,36 @@ const CountdownClock = ({ days, hours, minutes, seconds, completed }) => {
   }
 }
 
+const ImplementationLink = ({ text, href }) => {
+  return (
+    <Link className={S.panelLink} href={href} target="_blank" rel="noreferrer">
+      <LinkIcon />
+      {text}
+    </Link>
+  )
+}
+
+const CopyLink = () => {
+  const el = document.createElement("textarea")
+  const notice = document.getElementById("copiedNotice")
+  el.value = "https://www.bitcoincash.org/upgrade/"
+  el.setAttribute("readonly", "")
+  el.style.position = "absolute"
+  el.style.left = "-9999px"
+  document.body.appendChild(el)
+  el.select()
+  document.execCommand("copy")
+  document.body.removeChild(el)
+  notice.style.display = "inline-block"
+  setTimeout(function () {
+    notice.style.display = "none"
+  }, 1200)
+}
+
 const AnnouncementBar = () => {
   return (
     <Accordion
       className={S.accordionSection}
-      defaultActiveKey="0"
       style={{ backgroundImage: `url(${Network})` }}
     >
       <Accordion.Toggle as={S.accordionSection} eventKey="0">
@@ -133,19 +158,24 @@ const AnnouncementBar = () => {
                   upgrade.
                 </fbt>
               </p>
+              <p>
+                <fbt desc="Annoucement bar second paragraph">
+                  During the network upgrade, a chain split is likely to occur
+                  which could result in two chains: BCHA and BCHN.
+                </fbt>
+              </p>
               <div className={S.buttonContainer}>
-                <PrimaryButton
-                  noMarginLeft={true}
-                  className={S.primaryButton}
-                  buttonText={fbt(
-                    "Prepare for the Upgrade",
-                    "Annoucement bar 'Prepare for the Upgrade'"
-                  )}
-                  href={
-                    "https://blog.bitcoinabc.org/2020/09/14/preparing-businesses-for-a-successful-network-upgrade/"
-                  }
-                />
-
+                <div id="copiedNotice" className={S.copiedNotice}>
+                  <fbt desc="notice that link has been copied to clipboard">
+                    Link Copied
+                  </fbt>
+                </div>
+                <button className={S.panelButton} onClick={() => CopyLink()}>
+                  <ShareIcon />
+                  <fbt desc="'share' button on announcement bar at top of page">
+                    Share
+                  </fbt>
+                </button>
                 <Accordion.Toggle as={S.panelButton}>
                   <button className={S.panelButton}>
                     <fbt desc="'close' button on announcement bar at top of page to close the bar">
@@ -157,51 +187,37 @@ const AnnouncementBar = () => {
             </div>
             <div className={`${S.annoucementPanelInner} ${S.centerPanel}`}>
               <h4>
+                BCHA-
                 <fbt desc="Annoucement bar 'Compatible Implementations'">
                   Compatible Implementations:
                 </fbt>
               </h4>
-              <Link
-                className={S.panelLink}
+              <ImplementationLink
+                text="Bitcoin ABC 0.22.x"
                 href="https://www.bitcoinabc.org/2020-08-18-bitcoin-abc-0-22-0/"
-              >
-                <LinkIcon />
-                Bitcoin ABC 0.22.x
-              </Link>
+              />
+              <ImplementationLink
+                text="BCHD 0.17.0 (non-mining)"
+                href="https://github.com/gcash/bchd/releases"
+              />
               <h4>
-                <fbt desc="Annoucement bar 'Additional Information:'">
-                  Additional Information:
+                BCHN-
+                <fbt desc="Annoucement bar 'Compatible Implementations'">
+                  Compatible Implementations:
                 </fbt>
               </h4>
-              <Link
-                target="_blank"
-                rel="noreferrer"
-                className={S.panelLink}
-                href="/upgrade/business-guide.pdf"
-              >
-                <LinkIcon />
-                <fbt desc="Annoucement bar 'Upgrade: Quick Guide'">
-                  Upgrade: Quick Guide
-                </fbt>
-              </Link>
-              <Link
-                className={S.panelLink}
-                href="/spec/2020-11-15-upgrade.html"
-              >
-                <LinkIcon />
-                <fbt desc="Annoucement bar 'Upgrade Specification'">
-                  Upgrade Specification
-                </fbt>
-              </Link>
-              <Link
-                className={S.panelLink}
-                href="https://github.com/bitcoincashorg/bitcoincash.org/blob/master/workgroups/wg-testing/2020-11-15_upgrade_testnet.md"
-              >
-                <LinkIcon />
-                <fbt desc="Annoucement bar 'Testnet Information'">
-                  Testnet Information
-                </fbt>
-              </Link>
+              <ImplementationLink
+                text="Bitcoin ABC 0.22.6+ (BCHN network)"
+                href="https://www.bitcoinabc.org/releases/#0.22.6"
+              />
+              <ImplementationLink
+                text="BCHN 22.x.x"
+                href="https://bitcoincashnode.org/en/download.html"
+              />
+              <ImplementationLink
+                text="BCHD 0.17.0"
+                href="https://github.com/gcash/bchd/releases"
+              />
             </div>
           </div>
         </div>

--- a/v2/src/layout/announcement-bar.module.scss
+++ b/v2/src/layout/announcement-bar.module.scss
@@ -123,6 +123,7 @@
 .buttonContainer {
   width: 100%;
   text-align: center;
+  position: relative;
 }
 
 .accordionSection .panelLink {
@@ -152,11 +153,30 @@
   stroke: #bb5a00;
 }
 
+.panelButton svg {
+  stroke: #fff;
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  margin-right: 6px;
+  margin-top: -5px;
+}
+
 .completeHeader {
   background-color: #ff8d00;
   padding: 10px 0;
   border-radius: 3px;
   margin-top: 20px;
+}
+
+.copiedNotice {
+  background: #32385e;
+  display: none;
+  position: absolute;
+  padding: 16px 0;
+  width: 100%;
+  left: 0;
+  border-radius: 3px;
 }
 
 @media (max-width: 960px) {
@@ -212,7 +232,11 @@
   }
 
   .panelButton {
-    margin: 10px 0 30px 0;
+    margin: 10px 0 10px 0;
+  }
+
+  .panelButton:last-child {
+    margin-bottom: 50px;
   }
 
   .annoucementPanelInner button {
@@ -225,5 +249,12 @@
   .accordionSection {
     padding: 0px 10px;
     text-align: center;
+  }
+
+  .panelButton svg {
+    width: 15px;
+    height: 15px;
+    margin-right: 6px;
+    margin-top: -5px;
   }
 }

--- a/v2/src/pages/upgrade.js
+++ b/v2/src/pages/upgrade.js
@@ -2,24 +2,27 @@ import React from "react"
 import fbt from "fbt"
 import SEO from "components/seo"
 import { Container } from "react-bootstrap"
-import PrimaryButton from "components/buttons/primary-button"
 import Link from "global/link"
 import S from "./upgrade.module.scss"
 import UpgradeDate from "global/upgrade-date.js"
 import LinkIcon from "assets/icons/link.svg"
+
+const ImplementationLink = ({ text, href }) => {
+  return (
+    <Link className={S.panelLink} href={href} target="_blank" rel="noreferrer">
+      <LinkIcon />
+      {text}
+    </Link>
+  )
+}
 
 const UpgradePage = () => {
   return (
     <>
       <SEO title={fbt("How to Upgrade", "Upgrade page SEO title")} />
       <Container className={S.linkcontainer}>
-        <h2 className="centerh2">
-          <fbt desc="Upgrade page heading">How to Upgrade</fbt>
-        </h2>
         <h3>
-          <UpgradeDate />
-        </h3>
-        <h3>
+          <UpgradeDate /> |{" "}
           <fbt desc="Upgrade page subheadline">Planned Network Upgrade</fbt>
         </h3>
         <p>
@@ -30,51 +33,44 @@ const UpgradePage = () => {
             that their software is compatible with the upgrade.
           </fbt>
         </p>
-        <PrimaryButton
-          noMarginLeft={true}
-          buttonText={fbt(
-            "Prepare for the Upgrade",
-            "Upgrade page 'Prepare for the Upgrade' button"
-          )}
-          href={
-            "https://blog.bitcoinabc.org/2020/09/14/preparing-businesses-for-a-successful-network-upgrade/"
-          }
-        />
-
-        <h4 className={S.header}>
-          <fbt desc="Upgrade page 'Compatible Implementations'">
+        <p>
+          <fbt desc="upgrade page second paragraph">
+            During the network upgrade, a chain split is likely to occur which
+            could result in two chains: BCHA and BCHN.
+          </fbt>
+        </p>
+        <h4>
+          BCHA-
+          <fbt desc="Annoucement bar 'Compatible Implementations'">
             Compatible Implementations:
           </fbt>
         </h4>
-        <Link href="https://www.bitcoinabc.org/2020-08-18-bitcoin-abc-0-22-0/">
-          <LinkIcon />
-          Bitcoin ABC 0.22.x
-        </Link>
-        <h4 className={S.header}>
-          <fbt desc="Upgrade page 'Additional Information:'">
-            Additional Information:
+        <ImplementationLink
+          text="Bitcoin ABC 0.22.x"
+          href="https://www.bitcoinabc.org/2020-08-18-bitcoin-abc-0-22-0/"
+        />
+        <ImplementationLink
+          text="BCHD 0.17.0 (non-mining)"
+          href="https://github.com/gcash/bchd/releases"
+        />
+        <h4>
+          BCHN-
+          <fbt desc="Annoucement bar 'Compatible Implementations'">
+            Compatible Implementations:
           </fbt>
         </h4>
-        <a href="/upgrade/business-guide.pdf" target="_blank" rel="noreferrer">
-          <LinkIcon />
-          <fbt desc="Upgrade page 'upgrade guide' header">
-            Upgrade: Quick Guide
-          </fbt>
-        </a>
-        <br />
-        <Link href="/spec/2020-11-15-upgrade.html">
-          <LinkIcon />
-          <fbt desc="Upgrade page 'Upgrade Specification'">
-            Upgrade Specification
-          </fbt>
-        </Link>
-        <br />
-        <Link href="https://github.com/bitcoincashorg/bitcoincash.org/blob/master/workgroups/wg-testing/2020-11-15_upgrade_testnet.md">
-          <LinkIcon />
-          <fbt desc="Upgrade page 'Testnet Information'">
-            Testnet Information
-          </fbt>
-        </Link>
+        <ImplementationLink
+          text="Bitcoin ABC 0.22.6+ (BCHN network)"
+          href="https://www.bitcoinabc.org/releases/#0.22.6"
+        />
+        <ImplementationLink
+          text="BCHN 22.x.x"
+          href="https://bitcoincashnode.org/en/download.html"
+        />
+        <ImplementationLink
+          text="BCHD 0.17.0"
+          href="https://github.com/gcash/bchd/releases"
+        />
       </Container>
     </>
   )

--- a/v2/src/pages/upgrade.module.scss
+++ b/v2/src/pages/upgrade.module.scss
@@ -2,12 +2,29 @@
   margin-top: 60px;
 }
 
+.linkcontainer {
+  padding-top: 100px;
+  padding-bottom: 100px;
+}
+
 .linkcontainer a {
   display: inline-block;
   margin-bottom: 15px;
 }
 
-.linkcontainer svg {
+.linkcontainer h4 {
+  margin-top: 70px;
+}
+
+.panelLink {
+  padding: 0;
+  margin: 0 0 20px 0;
+  cursor: pointer;
+  width: 100%;
+  display: inline-block;
+}
+
+.panelLink svg {
   stroke: #ff8d00;
   display: inline-block;
   width: 20px;
@@ -16,12 +33,25 @@
   transition: all 200ms ease-in-out;
 }
 
-.linkcontainer a:hover svg {
+.panelLink:hover svg {
   stroke: #bb5a00;
 }
 
 @media (max-width: 760px) {
   .header {
     margin-top: 30px;
+  }
+
+  .linkcontainer {
+    padding-top: 50px;
+    padding-bottom: 50px;
+  }
+
+  .linkcontainer h4 {
+    margin-top: 40px;
+  }
+
+  .linkcontainer h4 {
+    font-size: 18px;
   }
 }


### PR DESCRIPTION
Updating the info in the announcement bar and upgrade page to reflect the latest info.
- added new text
- changed banner behavior to be closed by default
- added other compatible node links 
- added share button that copies the upgrade page url to clipboard